### PR TITLE
[FIX] project_tech_lead: onchange on tech_lead_id

### DIFF
--- a/project_tech_lead/views/project_task.xml
+++ b/project_tech_lead/views/project_task.xml
@@ -3,6 +3,17 @@
      License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
 <odoo>
 
+    <record model="ir.ui.view" id="quick_create_task_form">
+        <field name="name">quick.create.task.form (in project_tech_lead)</field>
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="project.quick_create_task_form" />
+        <field name="arch" type="xml">
+            <field name="project_id" position="after">
+                <field name="tech_lead_id" force_save="1" invisible="1" />
+            </field>
+        </field>
+    </record>
+
     <record model="ir.ui.view" id="project_task_form_view">
         <field name="name">project.task.form (in project_tech_lead)</field>
         <field name="model">project.task</field>


### PR DESCRIPTION
Esse PR cria um onchange no model `project.task` que atualiza o campo `tech_lead_id` de todas as tarefas quando o tech lead do projeto for alterado.