### PR TITLE
[FIX] l10n_br_delivery_picking_label: first_volume equal to zero.

### DIFF
--- a/l10n_br_delivery_picking_label/models/stock_picking.py
+++ b/l10n_br_delivery_picking_label/models/stock_picking.py
@@ -8,8 +8,8 @@ class StockPicking(models.Model):
 
     _inherit = "stock.picking"
 
-    first_volume = fields.Integer()
-    last_volume = fields.Integer()
+    first_volume = fields.Integer(default=1)
+    last_volume = fields.Integer(default=0)
     number_of_volumes = fields.Integer(
         string="Number of Volumes",
         default=0,
@@ -26,3 +26,10 @@ class StockPicking(models.Model):
             "target": "new",
         }
         return action
+
+    def write(self, vals):
+        if not self.last_volume:
+            if "number_of_volumes" in vals:
+                vals["last_volume"] = vals["number_of_volumes"]
+        res = super().write(vals)
+        return res

--- a/l10n_br_delivery_picking_label/report/report_delivery_picking_label.xml
+++ b/l10n_br_delivery_picking_label/report/report_delivery_picking_label.xml
@@ -31,9 +31,6 @@
                             <p style="text-align: right;"><span
                                 t-esc="volume_display"
                             />/<span t-field="picking.number_of_volumes" /></p>
-                            <p style="text-align: right;"><span
-                                t-field="picking.carrier_id"
-                            /></p>
                         </div>
                 </t>
             </t>

--- a/l10n_br_delivery_picking_label/wizards/delivery_picking_label_wizard.py
+++ b/l10n_br_delivery_picking_label/wizards/delivery_picking_label_wizard.py
@@ -29,6 +29,7 @@ class DeliveryPickingLabelWizard(models.TransientModel):
     @api.onchange("picking_id")
     def _onchange_picking_id(self):
         self.last_volume = self.picking_id.number_of_volumes
+        self.first_volume = 1
 
     @api.onchange("first_volume")
     def _onchange_first_volume(self):


### PR DESCRIPTION
Esse PR corrige a indexação em 0 no campo first_volume e deleta o campo `carrier_id` do template.