### PR TITLE
[14.0][ADD] Addon: sale_margin_product_cost_security

### DIFF
--- a/sale_margin_product_cost_security/README.rst
+++ b/sale_margin_product_cost_security/README.rst
@@ -1,0 +1,35 @@
+==========================
+Sale Product Cost Security
+==========================
+
+KMEE
+
+Purpose
+=======
+
+This module extends the functionality of the product_cost_security module to the purchase_price field of the sale_margin module.
+
+When the user does not belong to the group product_cost_group, he cannot see the "Cost" field in the Sale Order Line view.
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Go to ...
+
+Usage
+=====
+
+To use this module you need to:
+
+#. Go to product form view logged with this user and you will see the
+   standard_price field.
+
+#. Go to sale order line form view logged with this user and you will see the
+   purchase_price field.
+
+How to test
+===========
+
+...

--- a/sale_margin_product_cost_security/__manifest__.py
+++ b/sale_margin_product_cost_security/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Sale Product Cost Security",
+    "summary": """KMEE""",
+    "version": "14.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "KMEE",
+    "website": "https://github.com/KMEE/kmee-odoo-addons",
+    "depends": ["sale_margin", "product_cost_security"],
+    "data": [
+        "views/sale_order_line_views.xml",
+    ],
+    "demo": [],
+}

--- a/sale_margin_product_cost_security/views/sale_order_line_views.xml
+++ b/sale_margin_product_cost_security/views/sale_order_line_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2024 KMEE
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="sale_margin_sale_order_line" model="ir.ui.view">
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale_margin.sale_margin_sale_order_line" />
+        <field name="arch" type="xml">
+            <field name="purchase_price" position="attributes">
+                <attribute
+                    name="groups"
+                >product_cost_security.group_product_cost</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/setup/sale_margin_product_cost_security/odoo/addons/sale_margin_product_cost_security
+++ b/setup/sale_margin_product_cost_security/odoo/addons/sale_margin_product_cost_security
@@ -1,0 +1,1 @@
+../../../../sale_margin_product_cost_security

--- a/setup/sale_margin_product_cost_security/setup.py
+++ b/setup/sale_margin_product_cost_security/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Esse módulo esconde o campo "Cost" para os usuários que não estão no grupo `group_product_cost`.
![image](https://github.com/user-attachments/assets/36bc284a-fed6-43ee-8ef7-99a041c2f6f9)
