### PR TITLE
[15.0][FIX] sale_order_pos_report_plain_text: date order format

### DIFF
--- a/sale_order_pos_report_plain_text/report/report_saleorder_compact.xml
+++ b/sale_order_pos_report_plain_text/report/report_saleorder_compact.xml
@@ -8,7 +8,7 @@
 =========================================
 <!-- <span t-esc="o.company_id.name" /> -->
 PEDIDO DE VENDA
-Data de Emissao: <span t-esc="o.date_order.strftime('%m/%d/%Y %H:%M')" />
+Data de Emissao: <span t-esc="o.date_order" t-options='{"widget": "datetime"}' />
 Cliente : <span t-esc="o.partner_id.name" />
 Endereco: OZ
 CNPJ: <span t-esc="o.partner_id.vat" />


### PR DESCRIPTION
Além da formatação da data, havia também uma diferença na hora. O widget datatime resolve.