### PR TITLE
[14.0][IMP] sale_commission_manual_invoice: Altera  botões e estados

### DIFF
--- a/sale_commission_manual_invoice/i18n/pt_BR.po
+++ b/sale_commission_manual_invoice/i18n/pt_BR.po
@@ -1,0 +1,19 @@
+#. module: sale_commission_manual_invoice
+#: model_terms:ir.ui.view,arch_db:sale_commission_manual_invoice.view_settlement_form_inherit
+msgid "Confirm"
+msgstr "Confirmar"
+
+#. module: sale_commission_manual_invoice
+#: model_terms:ir.ui.view,arch_db:sale_commission_manual_invoice.view_settlement_form_inherit
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: sale_commission_manual_invoice
+#: model_terms:ir.ui.view,arch_db:sale_commission_manual_invoice.view_settlement_form_inherit
+msgid "Set to Settled"
+msgstr "Marcar como Aberto"
+
+#. module: sale_commission
+#: model:ir.model.fields.selection,name:sale_commission.selection__sale_commission_settlement__state__settled
+msgid "Open"
+msgstr "Aberto"

--- a/sale_commission_manual_invoice/models/sale_commission_settlement.py
+++ b/sale_commission_manual_invoice/models/sale_commission_settlement.py
@@ -1,12 +1,25 @@
 # Copyright 2025 KMEE
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import _, models
+from odoo import _, fields, models
 from odoo.exceptions import UserError
 
 
 class Settlement(models.Model):
     _inherit = "sale.commission.settlement"
+
+    state = fields.Selection(
+        selection=[
+            ("settled", "Open"),
+            ("paid", "Paid"),
+            ("invoiced", "Invoiced"),
+            ("cancel", "Canceled"),
+            ("except_invoice", "Invoice exception"),
+        ],
+        string="State",
+        readonly=True,
+        default="settled",
+    )
 
     def action_invoice(self):
         raise UserError(
@@ -15,6 +28,10 @@ class Settlement(models.Model):
                 Create invoices manually and mark settlements as invoiced."""
             )
         )
+
+    def action_confirm(self):
+        for settlement in self:
+            settlement.write({"state": "paid"})
 
     def action_mark_invoiced(self):
         for settlement in self:

--- a/sale_commission_manual_invoice/views/sale_commission_settlement.xml
+++ b/sale_commission_manual_invoice/views/sale_commission_settlement.xml
@@ -8,14 +8,21 @@
         <field name="inherit_id" ref="sale_commission.view_settlement_form" />
         <field name="priority">100</field>
         <field name="arch" type="xml">
+            <field name="state" position="replace">
+                <field
+                    name="state"
+                    widget="statusbar"
+                    statusbar_visible="settled,paid,cancel"
+                />
+            </field>
             <!-- Remove the original 'Make Invoice' button -->
             <xpath expr="//button[@name='action_invoice']" position="replace" />
             <xpath expr="//button[@name='action_cancel']" position="replace" />
             <!-- Add 'Mark as Invoiced' button -->
             <xpath expr="//field[@name='state']" position="after">
                 <button
-                    name="action_mark_invoiced"
-                    string="Mark as Invoiced"
+                    name="action_confirm"
+                    string="Confirm"
                     type="object"
                     class="btn-primary"
                     groups="base.group_user"
@@ -28,13 +35,6 @@
                     groups="base.group_user"
                 />
                 <button
-                    name="action_except_invoice"
-                    string="Set to Exception"
-                    type="object"
-                    class="btn-warning"
-                    groups="base.group_user"
-                />
-                <button
                     name="action_settle"
                     string="Set to Settled"
                     type="object"
@@ -43,5 +43,9 @@
                 />
             </xpath>
         </field>
+    </record>
+
+    <record id="sale_commission.menu_commission_make_invoices" model="ir.ui.menu">
+        <field name="active">False</field>
     </record>
 </odoo>


### PR DESCRIPTION
Alterações no model `sale.commission.settlement` do módulo `sale_commission_manual_invoice`.
Essas alterações excluem tudo referente à fatura:
- Exclui o botão "Gerar Fatura".
- Exclui o botão "Set to Exception".
- Exclui o menu "Criar faturas de comissão".
- Exclui o estado "Invoice exception".
- Exclui o estado "Faturado".

Essa outras alterações definem a nova nomenclatura:
- Renomeia o estado "Liquidado" para "Aberto".
- Renomeia o botão "Set to Settle" pelo botão "Marcar como Aberto".
- Cria o estado "Pago".
- Cria o botão "Confirmar".