### PR TITLE
[IMP] Add fabricante_complemento field to Adicao class

### DIFF
--- a/l10n_br_di/utils/lista_declaracoes.py
+++ b/l10n_br_di/utils/lista_declaracoes.py
@@ -740,6 +740,13 @@ class Adicao:
             "required": True,
         },
     )
+    fabricante_complemento: Optional[str] = field(
+        default=None,
+        metadata={
+            "name": "fabricanteComplemento",
+            "type": "Element",
+        },
+    )
     fabricante_estado: Optional[str] = field(
         default=None,
         metadata={


### PR DESCRIPTION
Adiciona campo fabricante_cidade na estrutura de classes da DI

Isso corrige um bug ao importar uma DI caso esse campo esteja presente