### PR TITLE
[14.0][IMP] l10n_br_di: map and exclude unexpected tags

### DIFF
--- a/l10n_br_di/models/l10n_br_di_declaracao.py
+++ b/l10n_br_di/models/l10n_br_di_declaracao.py
@@ -3,6 +3,9 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 import base64
+import typing
+import xml.etree.ElementTree as ET
+from dataclasses import is_dataclass
 from datetime import datetime
 
 from xsdata.formats.dataclass.parsers import XmlParser
@@ -214,15 +217,21 @@ class L10nBrDiDeclaracao(models.Model):
 
     informacao_complementar = fields.Text()
 
-    def importa_declaracao(self, arquivo=False):
+    def importa_declaracao(self, arquivo=False, detect_unmapped=False):
         if self.arquivo_declaracao:
             arquivo = self.arquivo_declaracao
 
         file_content = base64.b64decode(arquivo)
+        allowed_tags = collect_allowed_tags(ListaDeclaracoes)
+        xml_clean, unmapped = clean_unmapped_tags(
+            file_content.decode("utf-8"), allowed_tags
+        )
+
         parser = XmlParser()
         declaration_list = parser.from_string(
-            file_content.decode("utf-8"), ListaDeclaracoes
+            xml_clean.decode("utf-8"), ListaDeclaracoes
         )
+
         vals = self._importa_declaracao(declaration_list)
 
         if self:
@@ -232,12 +241,15 @@ class L10nBrDiDeclaracao(models.Model):
             self.di_pagamento_ids.unlink()
             self.update(vals)
             self.calcular_declaracao()
+            result = self
         else:
             vals["arquivo_declaracao"] = arquivo
-            res = self.create(vals)
-            res.calcular_declaracao()
+            result = self.create(vals)
+            result.calcular_declaracao()
 
-            return res
+        if detect_unmapped:
+            return result, unmapped
+        return result, []
 
     def _importa_declaracao(self, declaracoes):
         if not declaracoes.declaracao_importacao:
@@ -444,3 +456,47 @@ class L10nBrDiDeclaracao(models.Model):
         domain = [("declaracao_id", "=", self.id)]
         action["domain"] = domain
         return action
+
+
+def clean_unmapped_tags(xml_content, allowed_tags):
+    """
+    Remove tags não mapeadas do XML e retorna o novo XML e a lista de tags removidas.
+    """
+    tree = ET.fromstring(xml_content)
+    unmapped = set()
+
+    def recursive_clean(elem):
+        for child in list(elem):
+            if child.tag not in allowed_tags:
+                unmapped.add(child.tag)
+                elem.remove(child)
+            else:
+                recursive_clean(child)
+
+    recursive_clean(tree)
+    return ET.tostring(tree, encoding="utf-8"), list(unmapped)
+
+
+def collect_allowed_tags(cls, collected=None):
+    """
+    Coleta recursivamente todos os nomes de campos (tags) dos dataclasses xsdata.
+    """
+    if collected is None:
+        collected = set()
+    if not hasattr(cls, "__dataclass_fields__"):
+        return collected
+    for f in cls.__dataclass_fields__.values():
+        tag_name = f.metadata.get("name", f.name)
+        collected.add(tag_name)
+        typ = f.type
+        origin = getattr(typ, "__origin__", None)
+        if origin in (list, typing.List):
+            typ = typ.__args__[0]
+
+        if getattr(typ, "__origin__", None) is typing.Union:
+            args = [a for a in typ.__args__ if a is not type(None)]
+            if args:
+                typ = args[0]
+        if is_dataclass(typ):
+            collect_allowed_tags(typ, collected)
+    return collected

--- a/l10n_br_di/wizards/l10n_br_di_importa_di_wizard.py
+++ b/l10n_br_di/wizards/l10n_br_di_importa_di_wizard.py
@@ -1,7 +1,13 @@
 # Copyright 2024 KMEE
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+import base64
+import xml.etree.ElementTree as ET
+
 from odoo import fields, models
+
+from ..models.l10n_br_di_declaracao import collect_allowed_tags
+from ..utils.lista_declaracoes import ListaDeclaracoes
 
 
 class L10nBrImportaDiWizard(models.TransientModel):
@@ -10,13 +16,46 @@ class L10nBrImportaDiWizard(models.TransientModel):
     _description = "Wizard de Importação de Declaração Importação"
 
     arquivo_declaracao = fields.Binary()
+    unmapped_tags = fields.Text(readonly=True)
+    confirm_ignore_unmapped = fields.Boolean(string="Prosseguir mesmo assim?")
+
+    def _get_unmapped_tags(self, xml_content):
+        """
+        Identifica as tags XML que não estão mapeadas
+        E retorna uma lista das mesmas."""
+        allowed_tags = collect_allowed_tags(ListaDeclaracoes)
+        tree = ET.fromstring(xml_content)
+        unmapped = set()
+
+        def recursive(elem):
+            for child in elem:
+                if child.tag not in allowed_tags:
+                    unmapped.add(child.tag)
+                recursive(child)
+
+        recursive(tree)
+        return list(unmapped)
+
+    def check_unmapped_tags(self):
+        for wizard in self:
+            xml_content = base64.b64decode(wizard.arquivo_declaracao)
+            unmapped = self._get_unmapped_tags(xml_content)
+            wizard.unmapped_tags = "\n".join(unmapped) if unmapped else ""
+            wizard.confirm_ignore_unmapped = False
+        return {
+            "type": "ir.actions.act_window",
+            "res_model": "l10n_br_di.importa_di.wizard",
+            "view_mode": "form",
+            "res_id": self.id,
+            "target": "new",
+            "context": self.env.context,
+        }
 
     def doit(self):
         result_ids = []
-
         for wizard in self:
-            declaration = self.env["l10n_br_di.declaracao"].importa_declaracao(
-                wizard.arquivo_declaracao
+            declaration, _ = self.env["l10n_br_di.declaracao"].importa_declaracao(
+                wizard.arquivo_declaracao, detect_unmapped=True
             )
             result_ids.append(declaration.id)
         action = self.env.ref("l10n_br_di.l10n_br_di_declaracao_act_window").read([])[0]

--- a/l10n_br_di/wizards/l10n_br_di_importa_di_wizard.xml
+++ b/l10n_br_di/wizards/l10n_br_di_importa_di_wizard.xml
@@ -7,15 +7,42 @@
         <field name="model">l10n_br_di.importa_di.wizard</field>
         <field name="arch" type="xml">
             <form string="Importa DI Wizard">
+                <div
+                    class="alert alert-warning"
+                    attrs="{'invisible': [('unmapped_tags', '=', False)]}"
+                >
+                        <h3><strong
+                        >⚠️ Atenção: As Tags abaixo não seguem o padrão do XML e não serão importadas</strong></h3>
+                        <p>
+                            <field
+                            name="unmapped_tags"
+                            attrs="{'invisible': [('unmapped_tags','=',False)]}"
+                            readonly="1"
+                            nolabel="1"
+                        />
+                        </p>
+                    </div>
                 <group>
                     <field name="arquivo_declaracao" />
+                    <field
+                        name="confirm_ignore_unmapped"
+                        attrs="{'invisible': [('unmapped_tags','=',False)]}"
+                    />
                 </group>
                 <footer>
+                    <button
+                        name="check_unmapped_tags"
+                        string="Checar Tags Inválidas"
+                        class="btn-primary"
+                        type="object"
+                        attrs="{'invisible': [('unmapped_tags','!=',False)]}"
+                    />
                     <button
                         name="doit"
                         string="Importar"
                         class="btn-primary"
                         type="object"
+                        attrs="{'invisible': [('confirm_ignore_unmapped','=',False)]}"
                     />
                     <button string="Cancel" class="btn-default" special="cancel" />
                 </footer>


### PR DESCRIPTION
Essa PR faz com que seja possível importar qualquer DI mesmo com tags não mapeadas. Antes de importar o XML, ele verifica as tags que não são esperadas e as retorna em uma lista para o usuário verificar, caso ele queira prosseguir, o código exclui as tags da lista na hora da importação, caso não prossiga, apenas cancela normalmente

![image](https://github.com/user-attachments/assets/507da78e-6299-47a2-955d-1ec99a028515)
