### PR TITLE
[14.0][NEW] l10n_br_tax_manual_values

### DIFF
--- a/l10n_br_tax_manual_values/README.rst
+++ b/l10n_br_tax_manual_values/README.rst
@@ -1,0 +1,32 @@
+=========================
+L10n Br Tax Manual Values
+=========================
+
+l10n_br_tax_manual_values
+
+Purpose
+=======
+
+This module does this and that...
+
+Explain the use case.
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Go to ...
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Go to ...
+
+
+How to test
+===========
+
+...

--- a/l10n_br_tax_manual_values/__init__.py
+++ b/l10n_br_tax_manual_values/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_br_tax_manual_values/__manifest__.py
+++ b/l10n_br_tax_manual_values/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2025 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "L10n Br Tax Manual Values",
+    "summary": """l10n_br_tax_manual_values""",
+    "version": "14.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "KMEE",
+    "website": "https://github.com/KMEE/kmee-odoo-addons",
+    "depends": [
+        "l10n_br_account",
+        "l10n_br_fiscal",
+    ],
+    "data": [],
+    "demo": [],
+}

--- a/l10n_br_tax_manual_values/models/__init__.py
+++ b/l10n_br_tax_manual_values/models/__init__.py
@@ -1,0 +1,6 @@
+from . import account_move_line
+from . import account_move
+from . import account_tax
+from . import l10n_br_fiscal_document_line_mixin
+from . import l10n_br_fiscal_document_line_mixin_methods
+from . import l10n_br_fiscal_tax

--- a/l10n_br_tax_manual_values/models/__init__.py
+++ b/l10n_br_tax_manual_values/models/__init__.py
@@ -1,6 +1,6 @@
+from . import l10n_br_fiscal_document_line_mixin
 from . import account_move_line
 from . import account_move
 from . import account_tax
-from . import l10n_br_fiscal_document_line_mixin
 from . import l10n_br_fiscal_document_line_mixin_methods
 from . import l10n_br_fiscal_tax

--- a/l10n_br_tax_manual_values/models/account_move.py
+++ b/l10n_br_tax_manual_values/models/account_move.py
@@ -1,9 +1,13 @@
 # Copyright 2025 KMEE
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import api, models
 
 
 class AccountMove(models.Model):
 
     _inherit = "account.move"
+
+    @api.model
+    def _compute_taxes_mapped(self, base_line):
+        pass

--- a/l10n_br_tax_manual_values/models/account_move.py
+++ b/l10n_br_tax_manual_values/models/account_move.py
@@ -1,0 +1,9 @@
+# Copyright 2025 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class AccountMove(models.Model):
+
+    _inherit = "account.move"

--- a/l10n_br_tax_manual_values/models/account_move_line.py
+++ b/l10n_br_tax_manual_values/models/account_move_line.py
@@ -1,7 +1,7 @@
 # Copyright 2025 KMEE
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import api, models
 
 from .l10n_br_fiscal_document_line_mixin_methods import FISCAL_TAX_PREFIXES
 
@@ -20,3 +20,34 @@ class AccountMoveLine(models.Model):
                 tax_values[attr_name] = self.env.context.get(attr_name)
 
         return tax_values
+
+    def _get_price_total_and_subtotal(
+        self,
+        price_unit=None,
+        quantity=None,
+        discount=None,
+        currency=None,
+        product=None,
+        partner=None,
+        taxes=None,
+        move_type=None,
+    ):
+        pass
+
+    @api.model
+    def _get_price_total_and_subtotal_model(
+        self,
+        price_unit,
+        quantity,
+        discount,
+        currency,
+        product,
+        partner,
+        taxes,
+        move_type,
+    ):
+        pass
+
+    @api.onchange("fiscal_tax_ids")
+    def _onchange_fiscal_tax_ids(self):
+        pass

--- a/l10n_br_tax_manual_values/models/account_move_line.py
+++ b/l10n_br_tax_manual_values/models/account_move_line.py
@@ -3,7 +3,20 @@
 
 from odoo import models
 
+from .l10n_br_fiscal_document_line_mixin_methods import FISCAL_TAX_PREFIXES
+
 
 class AccountMoveLine(models.Model):
 
     _inherit = "account.move.line"
+
+    def _get_manual_tax_values_from_context(self):
+        tax_values = {}
+        suffixes = ["_base_manual", "_value_manual"]
+
+        for tax_prefix in FISCAL_TAX_PREFIXES:
+            for suffix in suffixes:
+                attr_name = tax_prefix + suffix
+                tax_values[attr_name] = self.env.context.get(attr_name)
+
+        return tax_values

--- a/l10n_br_tax_manual_values/models/account_move_line.py
+++ b/l10n_br_tax_manual_values/models/account_move_line.py
@@ -1,0 +1,9 @@
+# Copyright 2025 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class AccountMoveLine(models.Model):
+
+    _inherit = "account.move.line"

--- a/l10n_br_tax_manual_values/models/account_tax.py
+++ b/l10n_br_tax_manual_values/models/account_tax.py
@@ -1,0 +1,9 @@
+# Copyright 2025 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class AccountTax(models.Model):
+
+    _inherit = "account.tax"

--- a/l10n_br_tax_manual_values/models/account_tax.py
+++ b/l10n_br_tax_manual_values/models/account_tax.py
@@ -3,7 +3,46 @@
 
 from odoo import models
 
+from odoo.addons.l10n_br_fiscal.constants.fiscal import FINAL_CUSTOMER_NO
+
 
 class AccountTax(models.Model):
 
     _inherit = "account.tax"
+
+    def compute_all(
+        self,
+        price_unit,
+        currency=None,
+        quantity=1.0,
+        product=None,
+        partner=None,
+        is_refund=False,
+        handle_price_include=True,
+        fiscal_taxes=None,
+        operation_line=False,
+        ncm=None,
+        nbs=None,
+        nbm=None,
+        cest=None,
+        cfop=None,
+        discount_value=None,
+        insurance_value=None,
+        other_value=None,
+        ii_customhouse_charges=None,
+        freight_value=None,
+        fiscal_price=None,
+        fiscal_quantity=None,
+        uot_id=None,
+        icmssn_range=None,
+        icms_origin=None,
+        ind_final=FINAL_CUSTOMER_NO,
+        **kwargs,
+    ):
+        pass
+
+    def _compute_tax_base(self, tax, tax_dict, **kwargs):
+        pass
+
+    def _compute_icmsfcp(self, tax, taxes_dict, **kwargs):
+        pass

--- a/l10n_br_tax_manual_values/models/l10n_br_fiscal_document_line_mixin.py
+++ b/l10n_br_tax_manual_values/models/l10n_br_fiscal_document_line_mixin.py
@@ -1,0 +1,9 @@
+# Copyright 2025 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class FiscalDocumentLineMixin(models.AbstractModel):
+
+    _inherit = "l10n_br_fiscal.document.line.mixin"

--- a/l10n_br_tax_manual_values/models/l10n_br_fiscal_document_line_mixin.py
+++ b/l10n_br_tax_manual_values/models/l10n_br_fiscal_document_line_mixin.py
@@ -1,9 +1,220 @@
 # Copyright 2025 KMEE
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import fields, models
 
 
 class FiscalDocumentLineMixin(models.AbstractModel):
 
     _inherit = "l10n_br_fiscal.document.line.mixin"
+
+    issqn_base_manual = fields.Monetary(
+        string="Manual ISSQN Base",
+        help="Value of the ISSQN Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    issqn_value_manual = fields.Monetary(
+        string="Manual ISSQN Value",
+        help="Value of the ISSQN Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    issqn_wh_base_manual = fields.Monetary(
+        string="Manual ISSQN RET Base",
+        help="Value of the ISSQN RET Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    issqn_wh_value_manual = fields.Monetary(
+        string="Manual ISSQN RET Value",
+        help="Value of the ISSQN RET Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+    icms_base_manual = fields.Monetary(
+        string="Manual ICMS Base",
+        help="Value of the ICMS Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    icms_value_manual = fields.Monetary(
+        string="Manual ICMS Value",
+        help="Value of the ICMS Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+    icmsst_base_manual = fields.Monetary(
+        string="Manual ICMS ST Base",
+        help="Value of the ICMS ST Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    icmsst_value_manual = fields.Monetary(
+        string="Manual ICMS ST Value",
+        help="Value of the ICMS ST Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+    icmsst_wh_base_manual = fields.Monetary(
+        string="Manual ICMS ST RET Base",
+        help="Value of the ICMS ST RET Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    icmsst_wh_value_manual = fields.Monetary(
+        string="Manual ICMS ST RET Value",
+        help="Value of the ICMS ST RET Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+    ipi_base_manual = fields.Monetary(
+        string="Manual IPI Base",
+        help="Value of the IPI Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    ipi_value_manual = fields.Monetary(
+        string="Manual IPI Value",
+        help="Value of the IPI Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+    ii_base_manual = fields.Monetary(
+        string="Manual II Base",
+        help="Value of the II Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    ii_value_manual = fields.Monetary(
+        string="Manual II Value",
+        help="Value of the II Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+    cofins_base_manual = fields.Monetary(
+        string="Manual COFINS Base",
+        help="Value of the COFINS Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    cofins_value_manual = fields.Monetary(
+        string="Manual COFINS Value",
+        help="Value of the COFINS Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+    cofinsst_base_manual = fields.Monetary(
+        string="Manual COFINS ST Base",
+        help="Value of the COFINS ST Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    cofinsst_value_manual = fields.Monetary(
+        string="Manual COFINS ST Value",
+        help="Value of the COFINS ST Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+    cofins_wh_base_manual = fields.Monetary(
+        string="Manual COFINS RET Base",
+        help="Value of the COFINS RET Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    cofins_wh_value_manual = fields.Monetary(
+        string="Manual COFINS RET Value",
+        help="Value of the COFINS RET Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+    pis_base_manual = fields.Monetary(
+        string="Manual PIS Base",
+        help="Value of the PIS Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    pis_value_manual = fields.Monetary(
+        string="Manual PIS Value",
+        help="Value of the PIS Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+    pisst_base_manual = fields.Monetary(
+        string="Manual PIS ST Base",
+        help="Value of the PIS ST Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    pisst_value_manual = fields.Monetary(
+        string="Manual PIS ST Value",
+        help="Value of the PIS ST Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+    pis_wh_base_manual = fields.Monetary(
+        string="Manual PIS RET Base",
+        help="Value of the PIS RET Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    pis_wh_value_manual = fields.Monetary(
+        string="Manual PIS RET Value",
+        help="Value of the PIS RET Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+    csll_base_manual = fields.Monetary(
+        string="Manual CSLL Base",
+        help="Value of the CSLL Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    csll_value_manual = fields.Monetary(
+        string="Manual CSLL Value",
+        help="Value of the CSLL Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+    csll_wh_base_manual = fields.Monetary(
+        string="Manual CSLL RET Base",
+        help="Value of the CSLL RET Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    csll_wh_value_manual = fields.Monetary(
+        string="Manual CSLL RET Value",
+        help="Value of the CSLL RET Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+    irpj_base_manual = fields.Monetary(
+        string="Manual IRPJ Base",
+        help="Value of the IRPJ Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    irpj_value_manual = fields.Monetary(
+        string="Manual IRPJ Value",
+        help="Value of the IRPJ Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+    irpj_wh_base_manual = fields.Monetary(
+        string="Manual IRPJ RET Base",
+        help="Value of the IRPJ RET Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    irpj_wh_value_manual = fields.Monetary(
+        string="Manual IRPJ RET Value",
+        help="Value of the IRPJ RET Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+    inss_base_manual = fields.Monetary(
+        string="Manual INSS Base",
+        help="Value of the INSS Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    inss_value_manual = fields.Monetary(
+        string="Manual INSS Value",
+        help="Value of the INSS Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+    inss_wh_base_manual = fields.Monetary(
+        string="Manual INSS RET Base",
+        help="Value of the INSS RET Base calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )
+
+    inss_wh_value_manual = fields.Monetary(
+        string="Manual INSS Value",
+        help="Value of the INSS Value calculated manually. "
+        "Leave this field blank for automatic calculation.",
+    )

--- a/l10n_br_tax_manual_values/models/l10n_br_fiscal_document_line_mixin_methods.py
+++ b/l10n_br_tax_manual_values/models/l10n_br_fiscal_document_line_mixin_methods.py
@@ -1,0 +1,9 @@
+# Copyright 2025 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class FiscalDocumentLineMixinMethods(models.AbstractModel):
+
+    _inherit = "l10n_br_fiscal.document.line.mixin.methods"

--- a/l10n_br_tax_manual_values/models/l10n_br_fiscal_document_line_mixin_methods.py
+++ b/l10n_br_tax_manual_values/models/l10n_br_fiscal_document_line_mixin_methods.py
@@ -3,7 +3,40 @@
 
 from odoo import models
 
+FISCAL_TAX_PREFIXES = [
+    "icms",
+    "icmsst",
+    "issqn",
+    "issqn_wh",
+    "icmsst_wh",
+    "ipi",
+    "ii",
+    "cofins",
+    "cofinsst",
+    "cofins_wh",
+    "pis",
+    "pisst",
+    "pis_wh",
+    "csll",
+    "csll_wh",
+    "irpj",
+    "irpj_wh",
+    "inss",
+    "inss_wh",
+]
+
 
 class FiscalDocumentLineMixinMethods(models.AbstractModel):
 
     _inherit = "l10n_br_fiscal.document.line.mixin.methods"
+
+    def _prepare_br_manual_tax_dict(self):
+        manual_tax_dict = {}
+        suffixes = ["_base_manual", "_value_manual"]
+
+        for tax_prefix in FISCAL_TAX_PREFIXES:
+            for suffix in suffixes:
+                attr_name = tax_prefix + suffix
+                manual_tax_dict[attr_name] = getattr(self, attr_name)
+
+        return manual_tax_dict

--- a/l10n_br_tax_manual_values/models/l10n_br_fiscal_document_line_mixin_methods.py
+++ b/l10n_br_tax_manual_values/models/l10n_br_fiscal_document_line_mixin_methods.py
@@ -40,3 +40,6 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 manual_tax_dict[attr_name] = getattr(self, attr_name)
 
         return manual_tax_dict
+
+    def _compute_taxes(self, taxes, cst=None):
+        pass

--- a/l10n_br_tax_manual_values/models/l10n_br_fiscal_tax.py
+++ b/l10n_br_tax_manual_values/models/l10n_br_fiscal_tax.py
@@ -1,0 +1,9 @@
+# Copyright 2025 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class FiscalTax(models.Model):
+
+    _inherit = "l10n_br_fiscal.tax"

--- a/setup/l10n_br_tax_manual_values/odoo/addons/l10n_br_tax_manual_values
+++ b/setup/l10n_br_tax_manual_values/odoo/addons/l10n_br_tax_manual_values
@@ -1,0 +1,1 @@
+../../../../l10n_br_tax_manual_values

--- a/setup/l10n_br_tax_manual_values/setup.py
+++ b/setup/l10n_br_tax_manual_values/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Esse PR extrai a funcionalidade implementada na branch https://github.com/kmee/l10n-brazil/tree/14.0-imp-tax-manual-values e implementa no módulo `l10n_br_tax_manual_values`. A implementação pode ser melhor visualizada na comparação https://github.com/OCA/l10n-brazil/compare/14.0...kmee:l10n-brazil:14.0-imp-tax-manual-values .

Os commits estão organizados com os seguintes critérios:
- [X] Adiciona os módulos dependentes
 [NEW] Addon: l10n_br_tax_manual_values Just create the module and add the dependencies
- [X] Adiciona todos os _models_ que serão extendidos
[IMP] l10n_br_tax_manual_values: add models Just add the extension of each model
- [X] Adiciona todos os campos do _mixin_
[IMP] l10n_br_tax_manual_values: adds the mixin document line fields
- [X] Adiciona todos os métodos novos
[IMP] l10n_br_tax_manual_values: add methods
- [X] Adiciona todos os métodos que serão extendidos
[IMP] l10n_br_tax_manual_values: adds method signatures
- [ ] Implementa a extensão de cada método (talvez precise de mais de um commit)
- [ ] Implementa a extensão de cada view (talvez precise de mais de um commit)
- [ ] Implementa os testes

OBS: Havendo necessidade outros commits serão adicionados e catalogados aqui.
