### PR TITLE
[16][NEW] Addon: mail_role_filter

### DIFF
--- a/mail_role_filter/README.rst
+++ b/mail_role_filter/README.rst
@@ -1,0 +1,32 @@
+==================
+Mail Block By Role
+==================
+
+mail_block_by_role
+
+Purpose
+=======
+
+This module does this and that...
+
+Explain the use case.
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Go to ...
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Go to ...
+
+
+How to test
+===========
+
+...

--- a/mail_role_filter/__init__.py
+++ b/mail_role_filter/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/mail_role_filter/__manifest__.py
+++ b/mail_role_filter/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2025 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Mail Filter By Role",
+    "version": "16.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "KMEE",
+    "website": "https://kmee.com.br/",
+    "depends": ["mail", "base"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/mail_filter_role.xml",
+    ],
+    "demo": [],
+}

--- a/mail_role_filter/models/__init__.py
+++ b/mail_role_filter/models/__init__.py
@@ -1,0 +1,2 @@
+from . import mail_role_filter
+from . import mail_thread

--- a/mail_role_filter/models/mail_role_filter.py
+++ b/mail_role_filter/models/mail_role_filter.py
@@ -1,0 +1,14 @@
+# Copyright 2025 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class MailFilterRole(models.Model):
+
+    _name = "mail.role.filter"
+    _description = "Email sending filter by Role and Model"
+
+    role_id = fields.Many2one("res.users.role", required=True, ondelete="cascade")
+    model_id = fields.Many2one("ir.model", required=True, ondelete="cascade")
+    active = fields.Boolean(default=True)

--- a/mail_role_filter/models/mail_thread.py
+++ b/mail_role_filter/models/mail_thread.py
@@ -1,0 +1,43 @@
+# Copyright https://kmee.com.br/ KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class MailThread(models.AbstractModel):
+    _inherit = "mail.thread"
+
+    def _notify_get_recipients(self, message, msg_vals, **kwargs):
+        recipients_data = super()._notify_get_recipients(message, msg_vals, **kwargs)
+        if not recipients_data:
+            return recipients_data
+
+        model_name = self._name
+        roles = (
+            self.env["mail.role.filter"]
+            .sudo()
+            .search([("model_id.model", "=", model_name), ("active", "=", True)])
+            .mapped("role_id")
+        )
+        if not roles:
+            return recipients_data
+
+        recipients_data_filtered = []
+        for recipient in recipients_data:
+            for role in roles:
+                partner_id = self.env["res.partner"].browse(recipient["id"])
+                user_id = (
+                    self.env["res.users"]
+                    .sudo()
+                    .search([("partner_id", "=", partner_id.id)])
+                )
+                if role.id in user_id.role_ids.mapped("id"):
+                    recipients_data_filtered.append(recipient)
+
+        seen = set()
+        recipients_data_filtered = [
+            d
+            for d in recipients_data_filtered
+            if d["id"] not in seen and not seen.add(d["id"])
+        ]
+        return recipients_data_filtered

--- a/mail_role_filter/security/ir.model.access.csv
+++ b/mail_role_filter/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_mail_role_filter,access_mail_role_filter,model_mail_role_filter,base.group_user,1,1,1,1

--- a/mail_role_filter/views/mail_filter_role.xml
+++ b/mail_role_filter/views/mail_filter_role.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2025 KMEE
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record id="view_mail_block_role_form" model="ir.ui.view">
+        <field name="name">mail.role.filter.form</field>
+        <field name="model">mail.role.filter</field>
+        <field name="arch" type="xml">
+            <form>
+                <group>
+                    <field name="role_id" />
+                    <field name="model_id" />
+                    <field name="active" />
+                </group>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_mail_block_role_tree" model="ir.ui.view">
+        <field name="name">mail.role.filter.tree</field>
+        <field name="model">mail.role.filter</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="role_id" />
+                <field name="model_id" />
+                <field name="active" />
+            </tree>
+        </field>
+    </record>
+
+    <record id="action_mail_role_filter" model="ir.actions.act_window">
+        <field name="name">Filter Email by Role</field>
+        <field name="res_model">mail.role.filter</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <!-- <menuitem id="menu_mail_filter_role_root" name="Mail Filter Rules" parent="base.menu_administration"/> -->
+    <menuitem
+        id="menu_mail_filter_role"
+        name="Filter Email by Role"
+        parent="mail.mail_menu_technical"
+        action="action_mail_role_filter"
+    />
+
+</odoo>

--- a/setup/mail_role_filter/odoo/addons/mail_role_filter
+++ b/setup/mail_role_filter/odoo/addons/mail_role_filter
@@ -1,0 +1,1 @@
+../../../../mail_role_filter

--- a/setup/mail_role_filter/setup.py
+++ b/setup/mail_role_filter/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
O módulo `mail_role_filter` permite criar um filtro para envio de emails baseado na Função (res.partner.role).
No exemplo abaixo, todos emails relacionados a Folga (hr.leave) só será enviado para os usuários que possui a função cahamada "Função A".
<img width="448" height="238" alt="image" src="https://github.com/user-attachments/assets/b084d900-324b-48c1-a858-c749a86c4ac1" />
