### PR TITLE
[16.0][NEW] Addon: hr_holidays_sale_of_days_off

### DIFF
--- a/hr_holidays_sale_of_days_off/README.rst
+++ b/hr_holidays_sale_of_days_off/README.rst
@@ -1,0 +1,32 @@
+============================
+Hr Holidays Sale Of Days Off
+============================
+
+hr_holidays_sale_of_days_off
+
+Purpose
+=======
+
+This module does this and that...
+
+Explain the use case.
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Go to ...
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Go to ...
+
+
+How to test
+===========
+
+...

--- a/hr_holidays_sale_of_days_off/__init__.py
+++ b/hr_holidays_sale_of_days_off/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/hr_holidays_sale_of_days_off/__manifest__.py
+++ b/hr_holidays_sale_of_days_off/__manifest__.py
@@ -1,0 +1,22 @@
+# Copyright 2025 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Hr Holidays Sale Of Days Off",
+    "summary": """hr_holidays_sale_of_days_off""",
+    "version": "16.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "KMEE",
+    "website": "http://kmee.com.br",
+    "depends": [
+        "hr_holidays",
+    ],
+    "data": [
+        "views/hr_leave_allocation.xml",
+        "security/hr_leave_abono.xml",
+        "views/hr_leave_abono.xml",
+        "views/hr_employee.xml",
+    ],
+    "demo": [],
+    "installable": True,
+}

--- a/hr_holidays_sale_of_days_off/i18n/pt_BR.po
+++ b/hr_holidays_sale_of_days_off/i18n/pt_BR.po
@@ -1,0 +1,173 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* hr_holidays_sale_of_days_off
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-07-16 17:47+0000\n"
+"PO-Revision-Date: 2025-07-16 17:47+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: hr_holidays_sale_of_days_off
+#: model_terms:ir.ui.view,arch_db:hr_holidays_sale_of_days_off.hr_leave_allocation_form_view
+#: model_terms:ir.ui.view,arch_db:hr_holidays_sale_of_days_off.view_employee_form_leave_inherit
+msgid ""
+"<span class=\"o_stat_text\">\n"
+"                            Holiday Sale\n"
+"                        </span>"
+msgstr ""
+"<span class=\"o_stat_text\">\n"
+"                            Venda de Férias\n"
+"                        </span>"
+
+#. module: hr_holidays_sale_of_days_off
+#: model:ir.model.fields,field_description:hr_holidays_sale_of_days_off.field_hr_leave_abono__holiday_allocation_id
+msgid "Allocation"
+msgstr "Alocação"
+
+#. module: hr_holidays_sale_of_days_off
+#: model:ir.model.fields,help:hr_holidays_sale_of_days_off.field_hr_leave_abono__employee_id
+msgid "Choose the employee"
+msgstr "Escolha o funcionário"
+
+#. module: hr_holidays_sale_of_days_off
+#: model_terms:ir.ui.view,arch_db:hr_holidays_sale_of_days_off.hr_leave_abono_form_view
+msgid "Confirm"
+msgstr "Confirmar"
+
+#. module: hr_holidays_sale_of_days_off
+#: model:ir.model.fields,field_description:hr_holidays_sale_of_days_off.field_hr_leave_abono__create_uid
+msgid "Created by"
+msgstr "Criado por"
+
+#. module: hr_holidays_sale_of_days_off
+#: model:ir.model.fields,field_description:hr_holidays_sale_of_days_off.field_hr_leave_abono__create_date
+msgid "Created on"
+msgstr "Criado em"
+
+#. module: hr_holidays_sale_of_days_off
+#: model:ir.model.fields,field_description:hr_holidays_sale_of_days_off.field_hr_leave_abono__date
+#: model:ir.model.fields,help:hr_holidays_sale_of_days_off.field_hr_leave_abono__date
+msgid "Date"
+msgstr "Data"
+
+#. module: hr_holidays_sale_of_days_off
+#: model:ir.model.fields,field_description:hr_holidays_sale_of_days_off.field_hr_employee__days_off_sold_display
+#: model:ir.model.fields,field_description:hr_holidays_sale_of_days_off.field_hr_leave_allocation__days_off_sold_display
+msgid "Days Off Sold Display"
+msgstr "Exibição de dias de folga vendidos"
+
+#. module: hr_holidays_sale_of_days_off
+#: model_terms:ir.ui.view,arch_db:hr_holidays_sale_of_days_off.hr_leave_allocation_form_view
+#: model_terms:ir.ui.view,arch_db:hr_holidays_sale_of_days_off.view_employee_form_leave_inherit
+msgid "Days Sold"
+msgstr "Dias Vendidos"
+
+#. module: hr_holidays_sale_of_days_off
+#: model:ir.model.fields,field_description:hr_holidays_sale_of_days_off.field_hr_leave_abono__days_sold
+#: model:ir.model.fields,field_description:hr_holidays_sale_of_days_off.field_hr_leave_allocation__number_of_days_sold
+#: model:ir.model.fields,help:hr_holidays_sale_of_days_off.field_hr_leave_abono__days_sold
+#: model:ir.model.fields,help:hr_holidays_sale_of_days_off.field_hr_leave_allocation__number_of_days_sold
+msgid "Days sold"
+msgstr "Dias Vendidos"
+
+#. module: hr_holidays_sale_of_days_off
+#: model:ir.model.fields,field_description:hr_holidays_sale_of_days_off.field_hr_leave_abono__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: hr_holidays_sale_of_days_off
+#: model:ir.model.fields.selection,name:hr_holidays_sale_of_days_off.selection__hr_leave_abono__state__draft
+msgid "Draft"
+msgstr ""
+
+#. module: hr_holidays_sale_of_days_off
+#: model:ir.model,name:hr_holidays_sale_of_days_off.model_hr_employee
+#: model:ir.model.fields,field_description:hr_holidays_sale_of_days_off.field_hr_leave_abono__employee_id
+msgid "Employee"
+msgstr "Funcionário"
+
+#. module: hr_holidays_sale_of_days_off
+#: model_terms:ir.ui.view,arch_db:hr_holidays_sale_of_days_off.hr_leave_allocation_form_view
+msgid "Holiday Sale"
+msgstr "Venda de Férias"
+
+#. module: hr_holidays_sale_of_days_off
+#. odoo-python
+#: code:addons/hr_holidays_sale_of_days_off/models/hr_employee.py:0
+#: code:addons/hr_holidays_sale_of_days_off/models/hr_leave_allocation.py:0
+#, python-format
+msgid "Holiday Sales"
+msgstr "Vendas de Férias"
+
+#. module: hr_holidays_sale_of_days_off
+#: model:ir.model,name:hr_holidays_sale_of_days_off.model_hr_leave_abono
+msgid "Hr Leave Abono"
+msgstr ""
+
+#. module: hr_holidays_sale_of_days_off
+#: model:ir.model.fields,field_description:hr_holidays_sale_of_days_off.field_hr_leave_abono__id
+msgid "ID"
+msgstr ""
+
+#. module: hr_holidays_sale_of_days_off
+#: model:ir.model.fields,field_description:hr_holidays_sale_of_days_off.field_hr_leave_abono____last_update
+msgid "Last Modified on"
+msgstr "Última modificação em"
+
+#. module: hr_holidays_sale_of_days_off
+#: model:ir.model.fields,field_description:hr_holidays_sale_of_days_off.field_hr_leave_abono__write_uid
+msgid "Last Updated by"
+msgstr "Última atualização por"
+
+#. module: hr_holidays_sale_of_days_off
+#: model:ir.model.fields,field_description:hr_holidays_sale_of_days_off.field_hr_leave_abono__write_date
+msgid "Last Updated on"
+msgstr "Última atualização em"
+
+#. module: hr_holidays_sale_of_days_off
+#: model:ir.model.fields,field_description:hr_holidays_sale_of_days_off.field_hr_leave_abono__name
+msgid "Name"
+msgstr "Nome"
+
+#. module: hr_holidays_sale_of_days_off
+#: model:ir.model.fields.selection,name:hr_holidays_sale_of_days_off.selection__hr_leave_abono__state__paid
+msgid "Paid"
+msgstr "Pago"
+
+#. module: hr_holidays_sale_of_days_off
+#: model:ir.model.fields,field_description:hr_holidays_sale_of_days_off.field_hr_leave_abono__state
+msgid "State"
+msgstr "Estado"
+
+#. module: hr_holidays_sale_of_days_off
+#. odoo-python
+#: code:addons/hr_holidays_sale_of_days_off/models/hr_leave_abono.py:0
+#, python-format
+msgid "The requested number of days sold cannot be 0."
+msgstr "O número solicitado de dias vendidos não pode ser 0."
+
+#. module: hr_holidays_sale_of_days_off
+#. odoo-python
+#: code:addons/hr_holidays_sale_of_days_off/models/hr_leave_abono.py:0
+#: code:addons/hr_holidays_sale_of_days_off/models/hr_leave_abono.py:0
+#, python-format
+msgid "The requested quantity is not available for sale."
+msgstr "A quantidade solicitada não está disponível para venda."
+
+#. module: hr_holidays_sale_of_days_off
+#: model:ir.model,name:hr_holidays_sale_of_days_off.model_hr_leave_allocation
+msgid "Time Off Allocation"
+msgstr "Alocação de Folga"
+
+#. module: hr_holidays_sale_of_days_off
+#: model_terms:ir.ui.view,arch_db:hr_holidays_sale_of_days_off.view_employee_form_leave_inherit
+msgid "Vacation days sold"
+msgstr "Dias de férias vendidos"

--- a/hr_holidays_sale_of_days_off/models/__init__.py
+++ b/hr_holidays_sale_of_days_off/models/__init__.py
@@ -1,0 +1,3 @@
+from . import hr_leave_abono
+from . import hr_employee
+from . import hr_leave_allocation

--- a/hr_holidays_sale_of_days_off/models/hr_employee.py
+++ b/hr_holidays_sale_of_days_off/models/hr_employee.py
@@ -1,0 +1,48 @@
+# Copyright 2025 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from datetime import date
+
+from odoo import _, fields, models
+
+
+class HrEmployee(models.Model):
+
+    _inherit = "hr.employee"
+
+    days_off_sold_display = fields.Char(compute="_compute_days_off_sold_display")
+
+    def action_sale_of_days_off(self):
+        default_allocation_id = self._get_default_hr_leave_allocation_id()["id"]
+        return {
+            "name": _("Holiday Sales"),
+            "view_mode": "tree,form",
+            "res_model": "hr.leave.abono",
+            "target": "current",
+            "type": "ir.actions.act_window",
+            "context": {
+                "default_employee_id": self.id,
+                "default_holiday_allocation_id": default_allocation_id,
+                "default_date": date.today(),
+                "create_name_button": "Register Vacation Sale”",
+            },
+            "domain": [("employee_id", "=", self.id)],
+        }
+
+    def _get_default_hr_leave_allocation_id(self):
+        today = date.today()
+        allocation = self.env["hr.leave.allocation"].search(
+            [
+                ("employee_id", "=", self.id),
+                ("date_from", "<", today),
+                ("date_to", ">", today),
+            ],
+            limit=1,
+        )
+        return {"id": allocation.id, "allocation_id": allocation}
+
+    def _compute_days_off_sold_display(self):
+        self.ensure_one()
+        current_allocation = self._get_default_hr_leave_allocation_id()["allocation_id"]
+        value = current_allocation.number_of_days_sold
+        self.days_off_sold_display = int(value) if value == int(value) else value

--- a/hr_holidays_sale_of_days_off/models/hr_leave_abono.py
+++ b/hr_holidays_sale_of_days_off/models/hr_leave_abono.py
@@ -1,0 +1,58 @@
+# Copyright 2025 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class HrLeaveAbono(models.Model):
+
+    _name = "hr.leave.abono"
+    _description = "Hr Leave Abono"
+
+    name = fields.Char(default="Abono Pecuniário", required=True)
+    employee_id = fields.Many2one(
+        "hr.employee", string="Employee", required=True, help="Choose the employee"
+    )
+    holiday_allocation_id = fields.Many2one(
+        "hr.leave.allocation",
+        string="Allocation",
+        domain="""[
+            ('employee_id', '=', employee_id),
+            ('date_from',  '<', context_today().strftime('%Y-%m-%d')),
+            ('date_to', '>', context_today().strftime('%Y-%m-%d'))]""",
+        required=True,
+    )
+    date = fields.Date(help="Date", required=True)
+    days_sold = fields.Float(string="Days sold", help="Days sold", required=True)
+    state = fields.Selection(
+        selection=[("draft", "Draft"), ("paid", "Paid")],
+        required=True,
+        readonly=True,
+        copy=False,
+        default="draft",
+    )
+
+    @api.onchange("days_sold")
+    def _onchange_days_sold(self):
+        for abono in self:
+            if abono.days_sold:
+                number_of_days = abono.holiday_allocation_id.number_of_days_display
+                if number_of_days - abono.days_sold < 20:
+                    raise ValidationError(
+                        _("The requested quantity is not available for sale.")
+                    )
+
+    def action_confirm(self):
+        for abono in self:
+            if not abono.days_sold:
+                raise ValidationError(
+                    _("The requested number of days sold cannot be 0.")
+                )
+            number_of_days = abono.holiday_allocation_id.number_of_days_display
+            if number_of_days - abono.days_sold < 20:
+                raise ValidationError(
+                    _("The requested quantity is not available for sale.")
+                )
+            abono.holiday_allocation_id.sell_days(abono.days_sold)
+            abono.state = "paid"

--- a/hr_holidays_sale_of_days_off/models/hr_leave_allocation.py
+++ b/hr_holidays_sale_of_days_off/models/hr_leave_allocation.py
@@ -1,0 +1,44 @@
+# Copyright 2025 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from datetime import date
+
+from odoo import _, api, fields, models
+
+
+class HrLeaveAllocation(models.Model):
+
+    _inherit = "hr.leave.allocation"
+
+    number_of_days_sold = fields.Float(string="Days sold", help="Days sold", default=0)
+    days_off_sold_display = fields.Char(compute="_compute_days_off_sold_display")
+
+    def sell_days(self, days):
+        self.ensure_one()
+        self.number_of_days_sold += days
+        self.number_of_days -= days
+
+    def action_sale_of_days_off(self):
+        return {
+            "name": _("Holiday Sales"),
+            "view_mode": "tree,form",
+            "res_model": "hr.leave.abono",
+            "target": "current",
+            "type": "ir.actions.act_window",
+            "context": {
+                "default_employee_id": self.employee_id.id,
+                "default_holiday_allocation_id": self.id,
+                "default_date": date.today(),
+                "create_name_button": "Register Vacation Sale”",
+            },
+            "domain": [
+                ("employee_id", "=", self.employee_id.id),
+                ("holiday_allocation_id", "=", self.id),
+            ],
+        }
+
+    @api.depends("number_of_days_sold")
+    def _compute_days_off_sold_display(self):
+        self.ensure_one()
+        value = self.number_of_days_sold
+        self.days_off_sold_display = int(value) if value == int(value) else value

--- a/hr_holidays_sale_of_days_off/security/hr_leave_abono.xml
+++ b/hr_holidays_sale_of_days_off/security/hr_leave_abono.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2025 KMEE
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.model.access" id="hr_leave_abono_access_name">
+        <field name="name">hr.leave.abono user</field>
+        <field name="model_id" ref="model_hr_leave_abono" />
+        <field name="group_id" ref="base.group_user" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_unlink" eval="0" />
+    </record>
+
+    <record model="ir.model.access" id="hr_leave_abono_access_manager">
+        <field name="name">hr.leave.abono manager</field>
+        <field name="model_id" ref="model_hr_leave_abono" />
+        <field name="group_id" ref="hr_holidays.group_hr_holidays_user" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_create" eval="1" />
+        <field name="perm_write" eval="1" />
+        <field name="perm_unlink" eval="1" />
+    </record>
+
+</odoo>

--- a/hr_holidays_sale_of_days_off/views/hr_employee.xml
+++ b/hr_holidays_sale_of_days_off/views/hr_employee.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2025 KMEE
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="view_employee_form_leave_inherit">
+        <field name="model">hr.employee</field>
+        <field name="inherit_id" ref="hr_holidays.view_employee_form_leave_inherit" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//button[@name='action_time_off_dashboard'][@icon='fa-calendar']"
+                position="after"
+            >
+                <button
+                    name="action_sale_of_days_off"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-dollar"
+                    context="{'search_default_employee_ids': active_id}"
+                    groups="hr_holidays.group_hr_holidays_user"
+                    help="Vacation days sold"
+                >
+                    <div
+                        class="o_field_widget o_stat_info"
+                        attrs="{'invisible': [('allocation_display', '=', '0')]}"
+                    >
+                        <span class="o_stat_value">
+                            <field name="days_off_sold_display" /> Days Sold
+                        </span>
+                        <span class="o_stat_text">
+                            Holiday Sale
+                        </span>
+                    </div>
+                </button>
+
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/hr_holidays_sale_of_days_off/views/hr_leave_abono.xml
+++ b/hr_holidays_sale_of_days_off/views/hr_leave_abono.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2025 KMEE
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="hr_leave_abono_form_view">
+        <field name="model">hr.leave.abono</field>
+        <field name="arch" type="xml">
+            <form>
+                <header>
+                    <field name="state" widget="statusbar" />
+                    <button
+                        class="oe_highlight"
+                        name="action_confirm"
+                        string="Confirm"
+                        type="object"
+                        attrs="{'invisible': [('state','!=', 'draft')]}"
+                    />
+                </header>
+                <sheet>
+                    <group>
+                        <field
+                            name="name"
+                            attrs="{'readonly': [('state', '=', 'paid')]}"
+                        />
+                        <field
+                            name="employee_id"
+                            attrs="{'readonly': [('state', '=', 'paid')]}"
+                        />
+                        <field
+                            name="holiday_allocation_id"
+                            attrs="{'readonly': [('state', '=', 'paid')]}"
+                        />
+                        <field
+                            name="date"
+                            attrs="{'readonly': [('state', '=', 'paid')]}"
+                        />
+                        <field
+                            name="days_sold"
+                            attrs="{'readonly': [('state', '=', 'paid')]}"
+                        />
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="hr_leave_abono_tree_view">
+        <field name="model">hr.leave.abono</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name" />
+                <field name="employee_id" />
+                <field name="holiday_allocation_id" />
+                <field name="date" />
+                <field name="days_sold" />
+                <field name="state" />
+            </tree>
+        </field>
+    </record>
+</odoo>

--- a/hr_holidays_sale_of_days_off/views/hr_leave_allocation.xml
+++ b/hr_holidays_sale_of_days_off/views/hr_leave_allocation.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2025 KMEE
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="hr_leave_allocation_form_view">
+        <field name="model">hr.leave.allocation</field>
+        <field name="inherit_id" ref="hr_holidays.hr_leave_allocation_view_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//div[@name='button_box']/button[@name='%(hr_holidays.hr_leave_action_holiday_allocation_id)d']"
+                position="after"
+            >
+                <button
+                    class="oe_stat_button"
+                    icon="fa-dollar"
+                    type="object"
+                    name="action_sale_of_days_off"
+                    help="Holiday Sale"
+                    groups="hr_holidays.group_hr_holidays_user"
+                >
+                    <div class="o_stat_info">
+                        <span class="o_stat_value">
+                            <field name="days_off_sold_display" /> Days Sold
+                        </span>
+                        <span class="o_stat_text">
+                            Holiday Sale
+                        </span>
+                    </div>
+                </button>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/setup/hr_holidays_sale_of_days_off/odoo/addons/hr_holidays_sale_of_days_off
+++ b/setup/hr_holidays_sale_of_days_off/odoo/addons/hr_holidays_sale_of_days_off
@@ -1,0 +1,1 @@
+../../../../hr_holidays_sale_of_days_off

--- a/setup/hr_holidays_sale_of_days_off/setup.py
+++ b/setup/hr_holidays_sale_of_days_off/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Esse PR adiciona o módulo `hr_holidays_sale_of_days_off` que possibilida registrar a venda de dias de folga de uma alocação.