### PR TITLE
[16.0][IMP] hr_holidays_sale_of days_off: Melhora de usabilidade

### DIFF
--- a/hr_holidays_sale_of_days_off/__manifest__.py
+++ b/hr_holidays_sale_of_days_off/__manifest__.py
@@ -12,6 +12,7 @@
         "hr_holidays",
     ],
     "data": [
+        "views/hr_leave_type.xml",
         "views/hr_leave_allocation.xml",
         "security/hr_leave_abono.xml",
         "views/hr_leave_abono.xml",

--- a/hr_holidays_sale_of_days_off/i18n/pt_BR.po
+++ b/hr_holidays_sale_of_days_off/i18n/pt_BR.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0\n"
+"Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-22 19:33+0000\n"
-"PO-Revision-Date: 2025-07-22 19:33+0000\n"
+"POT-Creation-Date: 2025-08-14 14:14+0000\n"
+"PO-Revision-Date: 2025-08-14 14:14+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -100,6 +100,11 @@ msgid "Employee"
 msgstr "Funcionário"
 
 #. module: hr_holidays_sale_of_days_off
+#: model:ir.model.fields,field_description:hr_holidays_sale_of_days_off.field_hr_leave_abono__holiday_allocation_period
+msgid "Holiday Allocation Period"
+msgstr "Período"
+
+#. module: hr_holidays_sale_of_days_off
 #: model_terms:ir.ui.view,arch_db:hr_holidays_sale_of_days_off.hr_leave_allocation_form_view
 msgid "Holiday Sale"
 msgstr "Venda de Férias"
@@ -115,9 +120,15 @@ msgid "Holiday Sales"
 msgstr "Vendas de Férias"
 
 #. module: hr_holidays_sale_of_days_off
+#: model:ir.model.fields,field_description:hr_holidays_sale_of_days_off.field_hr_leave_allocation__hr_holidays_sale_of_days_off
+#: model:ir.model.fields,field_description:hr_holidays_sale_of_days_off.field_hr_leave_type__hr_holidays_sale_of_days_off
+msgid "Hr Holidays Sale Of Days Off"
+msgstr "Permitir Venda de Férias"
+
+#. module: hr_holidays_sale_of_days_off
 #: model:ir.model,name:hr_holidays_sale_of_days_off.model_hr_leave_abono
 msgid "Hr Leave Abono"
-msgstr ""
+msgstr "Venda de Férias"
 
 #. module: hr_holidays_sale_of_days_off
 #: model:ir.model.fields,field_description:hr_holidays_sale_of_days_off.field_hr_leave_abono__id
@@ -173,6 +184,11 @@ msgstr "A quantidade solicitada não está disponível para venda."
 #: model:ir.model,name:hr_holidays_sale_of_days_off.model_hr_leave_allocation
 msgid "Time Off Allocation"
 msgstr "Alocação de Folga"
+
+#. module: hr_holidays_sale_of_days_off
+#: model:ir.model,name:hr_holidays_sale_of_days_off.model_hr_leave_type
+msgid "Time Off Type"
+msgstr "Tipo de Folga"
 
 #. module: hr_holidays_sale_of_days_off
 #: model_terms:ir.ui.view,arch_db:hr_holidays_sale_of_days_off.view_employee_form_leave_inherit

--- a/hr_holidays_sale_of_days_off/models/__init__.py
+++ b/hr_holidays_sale_of_days_off/models/__init__.py
@@ -1,3 +1,4 @@
 from . import hr_leave_abono
 from . import hr_employee
 from . import hr_leave_allocation
+from . import hr_leave_type

--- a/hr_holidays_sale_of_days_off/models/hr_leave_abono.py
+++ b/hr_holidays_sale_of_days_off/models/hr_leave_abono.py
@@ -18,8 +18,12 @@ class HrLeaveAbono(models.Model):
         "hr.leave.allocation",
         string="Allocation",
         domain="""[
-            ('employee_id', '=', employee_id)]""",
+            ('employee_id', '=', employee_id),
+            ('hr_holidays_sale_of_days_off', '=', True)]""",
         required=True,
+    )
+    holiday_allocation_period = fields.Char(
+        compute="_compute_holiday_allocation_period"
     )
     date = fields.Date(help="Date", required=True)
     days_sold = fields.Float(string="Days sold", help="Days sold", required=True)
@@ -54,3 +58,12 @@ class HrLeaveAbono(models.Model):
                 )
             abono.holiday_allocation_id.sell_days(abono.days_sold)
             abono.state = "paid"
+
+    @api.depends("holiday_allocation_id")
+    def _compute_holiday_allocation_period(self):
+        for record in self:
+            record.holiday_allocation_period = False
+            if record.holiday_allocation_id:
+                date_from = record.holiday_allocation_id.date_from
+                date_to = record.holiday_allocation_id.date_to
+                record.holiday_allocation_period = ("%s - %s") % (date_from, date_to)

--- a/hr_holidays_sale_of_days_off/models/hr_leave_allocation.py
+++ b/hr_holidays_sale_of_days_off/models/hr_leave_allocation.py
@@ -12,6 +12,9 @@ class HrLeaveAllocation(models.Model):
 
     number_of_days_sold = fields.Float(string="Days sold", help="Days sold", default=0)
     days_off_sold_display = fields.Char(compute="_compute_days_off_sold_display")
+    hr_holidays_sale_of_days_off = fields.Boolean(
+        related="holiday_status_id.hr_holidays_sale_of_days_off"
+    )
 
     def sell_days(self, days):
         self.ensure_one()

--- a/hr_holidays_sale_of_days_off/models/hr_leave_type.py
+++ b/hr_holidays_sale_of_days_off/models/hr_leave_type.py
@@ -1,0 +1,11 @@
+# Copyright 2025 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class HrLeaveType(models.Model):
+
+    _inherit = "hr.leave.type"
+
+    hr_holidays_sale_of_days_off = fields.Boolean()

--- a/hr_holidays_sale_of_days_off/views/hr_leave_abono.xml
+++ b/hr_holidays_sale_of_days_off/views/hr_leave_abono.xml
@@ -31,6 +31,7 @@
                             name="holiday_allocation_id"
                             attrs="{'readonly': [('state', '=', 'paid')]}"
                         />
+                        <field name="holiday_allocation_period" />
                         <field
                             name="date"
                             attrs="{'readonly': [('state', '=', 'paid')]}"
@@ -52,6 +53,7 @@
                 <field name="name" />
                 <field name="employee_id" />
                 <field name="holiday_allocation_id" />
+                <field name="holiday_allocation_period" />
                 <field name="date" />
                 <field name="days_sold" />
                 <field name="state" />

--- a/hr_holidays_sale_of_days_off/views/hr_leave_type.xml
+++ b/hr_holidays_sale_of_days_off/views/hr_leave_type.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2025 KMEE
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="edit_holiday_status_form">
+        <field name="model">hr.leave.type</field>
+        <field name="inherit_id" ref="hr_holidays.edit_holiday_status_form" />
+        <field name="arch" type="xml">
+            <field name="leave_validation_type" position="after">
+                <field name="hr_holidays_sale_of_days_off" />
+            </field>
+        </field>
+    </record>
+
+
+
+</odoo>


### PR DESCRIPTION
Adicona o campo Período na Venda de Férias, que corresponde ao período de vigência da Alocação.
<img width="1268" height="305" alt="image" src="https://github.com/user-attachments/assets/6365d536-b4da-4894-91d4-4b415ecba8d6" />

Adiciona o campo Permitir Venda de Férias no Tipo de Férias, e melhora do domínio do campo Alocação lá na Venda de Férias. 
<img width="435" height="166" alt="image" src="https://github.com/user-attachments/assets/7ca9435e-b36a-47c7-aca1-82c202df03ff" />
