### PR TITLE
[NEW] Addon: mail_thread_cc_bcc

### DIFF
--- a/mail_thread_cc_bcc/README.rst
+++ b/mail_thread_cc_bcc/README.rst
@@ -1,0 +1,32 @@
+==================
+Mail Thread Cc Bcc
+==================
+
+kmee
+
+Purpose
+=======
+
+This module does this and that...
+
+Explain the use case.
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Go to ...
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Go to ...
+
+
+How to test
+===========
+
+...

--- a/mail_thread_cc_bcc/__init__.py
+++ b/mail_thread_cc_bcc/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/mail_thread_cc_bcc/__manifest__.py
+++ b/mail_thread_cc_bcc/__manifest__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Mail Thread Cc Bcc",
+    "summary": """kmee""",
+    "version": "16.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "KMEE",
+    "website": "https://github.com/KMEE/kmee-odoo-addons",
+    "depends": ["mail"],
+    "data": [],
+    "demo": [],
+}

--- a/mail_thread_cc_bcc/models/__init__.py
+++ b/mail_thread_cc_bcc/models/__init__.py
@@ -1,0 +1,1 @@
+from . import mail_thread

--- a/mail_thread_cc_bcc/models/mail_thread.py
+++ b/mail_thread_cc_bcc/models/mail_thread.py
@@ -1,0 +1,26 @@
+# Copyright 2025 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class MailThread(models.AbstractModel):
+
+    _inherit = "mail.thread"
+
+    @api.model
+    def message_route(
+        self, message, message_dict, model=None, thread_id=None, custom_values=None
+    ):
+        email_cc = message_dict.get("cc", "")
+        email_cco = message_dict.get("bcc", "")
+        all_cc = ",".join(filter(None, [email_cc, email_cco]))
+        if all_cc:
+            self.env["mail.thread"]._get_cc_localparts(all_cc)
+            current_recipients = message_dict.get("recipients", "")
+            message_dict["recipients"] = (
+                f"{current_recipients},{all_cc}" if current_recipients else all_cc
+            )
+        return super().message_route(
+            message, message_dict, model, thread_id, custom_values
+        )

--- a/setup/mail_thread_cc_bcc/odoo/addons/mail_thread_cc_bcc
+++ b/setup/mail_thread_cc_bcc/odoo/addons/mail_thread_cc_bcc
@@ -1,0 +1,1 @@
+../../../../mail_thread_cc_bcc

--- a/setup/mail_thread_cc_bcc/setup.py
+++ b/setup/mail_thread_cc_bcc/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Este PR estende o comportamento padrão do modelo mail.thread para incluir os destinatários em CC e CCO (Bcc) no processo de roteamento de mensagens recebidas via e-mail.

Principais alterações:

Sobrescrita do método message_route para injetar os endereços de CC e CCO em message_dict['recipients'].

Garantia de compatibilidade total com o fluxo nativo de roteamento de mensagens do Odoo.

Motivação:
Por padrão, o Odoo ignora os endereços em CC e CCO no roteamento de e-mails. Este patch permite que esses destinatários também sejam considerados, assegurando que mensagens enviadas com cópias cheguem corretamente às threads ou registros relevantes.