### PR TITLE
Crm estágios duração

### DIFF
--- a/crm_lead_stage_duration/__init__.py
+++ b/crm_lead_stage_duration/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/crm_lead_stage_duration/__manifest__.py
+++ b/crm_lead_stage_duration/__manifest__.py
@@ -1,0 +1,19 @@
+{
+    "name": "CRM Lead Stage Duration",
+    "version": "16.0.1.0.0",
+    "summary": "Track time spent by opportunities in each CRM stage",
+    "category": "Sales/CRM",
+    "author": "KMEE, Diego Paradeda",
+    "website": "https://github.com/kmee/kmee-odoo-addons",
+    "license": "AGPL-3",
+    "depends": [
+        "crm",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/crm_lead_views.xml",
+        "views/crm_lead_stage_duration_views.xml",
+    ],
+    "installable": True,
+    "application": False,
+}

--- a/crm_lead_stage_duration/__manifest__.py
+++ b/crm_lead_stage_duration/__manifest__.py
@@ -3,7 +3,7 @@
     "version": "16.0.1.0.0",
     "summary": "Track time spent by opportunities in each CRM stage",
     "category": "Sales/CRM",
-    "author": "KMEE, Diego Paradeda",
+    "author": "KMEE",
     "website": "https://github.com/kmee/kmee-odoo-addons",
     "license": "AGPL-3",
     "depends": [

--- a/crm_lead_stage_duration/models/__init__.py
+++ b/crm_lead_stage_duration/models/__init__.py
@@ -1,0 +1,3 @@
+from . import crm_lead
+from . import crm_lead_stage_duration
+from . import crm_lead_stage_duration_report

--- a/crm_lead_stage_duration/models/crm_lead.py
+++ b/crm_lead_stage_duration/models/crm_lead.py
@@ -1,5 +1,6 @@
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+# Copyright (C) 2025-Today - KMEE (<http://www.kmee.com.br>).
 # @author Diego Paradeda <diego.paradeda@kmee.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
 

--- a/crm_lead_stage_duration/models/crm_lead.py
+++ b/crm_lead_stage_duration/models/crm_lead.py
@@ -1,0 +1,98 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+# @author Diego Paradeda <diego.paradeda@kmee.com.br>
+
+from odoo import api, fields, models
+
+from .crm_lead_stage_duration import display_duration
+
+
+class CrmLead(models.Model):
+    _inherit = "crm.lead"
+
+    stage_duration_ids = fields.One2many(
+        comodel_name="crm.lead.stage.duration",
+        inverse_name="lead_id",
+        string="Stage Durations",
+        copy=False,
+    )
+    current_stage_total_duration_seconds = fields.Float(
+        string="Current Stage Total Duration (seconds)",
+        compute="_compute_current_stage_total_duration",
+    )
+    current_stage_total_duration = fields.Char(
+        string="Current Stage Total Duration",
+        compute="_compute_current_stage_total_duration",
+    )
+
+    @api.depends(
+        "stage_id",
+        "stage_duration_ids.stage_id",
+        "stage_duration_ids.start_date",
+        "stage_duration_ids.end_date",
+    )
+    def _compute_current_stage_total_duration(self):
+        now = fields.Datetime.now()
+        for lead in self:
+            total_seconds = 0.0
+            if lead.stage_id:
+                stage_lines = lead.stage_duration_ids.filtered(
+                    lambda line: line.stage_id == lead.stage_id
+                )
+                for line in stage_lines:
+                    if not line.start_date:
+                        continue
+                    stop_date = line.end_date or now
+                    total_seconds += (stop_date - line.start_date).total_seconds()
+            lead.current_stage_total_duration_seconds = max(total_seconds, 0.0)
+            lead.current_stage_total_duration = (
+                display_duration(total_seconds, 4) if total_seconds else ""
+            )
+
+    def _close_stage_duration_line(self, end_date=None):
+        end_date = end_date or fields.Datetime.now()
+        open_lines = self.env["crm.lead.stage.duration"].search(
+            [("lead_id", "in", self.ids), ("end_date", "=", False)]
+        )
+        if open_lines:
+            open_lines.write({"end_date": end_date})
+
+    def _open_stage_duration_line(self, start_date=None):
+        start_date = start_date or fields.Datetime.now()
+        values = []
+        for lead in self.filtered("stage_id"):
+            values.append(
+                {
+                    "lead_id": lead.id,
+                    "stage_id": lead.stage_id.id,
+                    "team_id": lead.team_id.id,
+                    "user_id": self.env.user.id,
+                    "start_date": start_date,
+                }
+            )
+        if values:
+            self.env["crm.lead.stage.duration"].create(values)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        leads = super().create(vals_list)
+        now = fields.Datetime.now()
+        leads._close_stage_duration_line(end_date=now)
+        leads._open_stage_duration_line(start_date=now)
+        return leads
+
+    def write(self, vals):
+        previous_stage_by_lead = {}
+        if "stage_id" in vals:
+            previous_stage_by_lead = {lead.id: lead.stage_id.id for lead in self}
+
+        result = super().write(vals)
+
+        if previous_stage_by_lead:
+            changed_leads = self.filtered(
+                lambda lead: previous_stage_by_lead.get(lead.id) != lead.stage_id.id
+            )
+            if changed_leads:
+                now = fields.Datetime.now()
+                changed_leads._close_stage_duration_line(end_date=now)
+                changed_leads._open_stage_duration_line(start_date=now)
+        return result

--- a/crm_lead_stage_duration/models/crm_lead_stage_duration.py
+++ b/crm_lead_stage_duration/models/crm_lead_stage_duration.py
@@ -1,5 +1,6 @@
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+# Copyright (C) 2025-Today - KMEE (<http://www.kmee.com.br>).
 # @author Diego Paradeda <diego.paradeda@kmee.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
 

--- a/crm_lead_stage_duration/models/crm_lead_stage_duration.py
+++ b/crm_lead_stage_duration/models/crm_lead_stage_duration.py
@@ -1,0 +1,115 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+# @author Diego Paradeda <diego.paradeda@kmee.com.br>
+
+from odoo import api, fields, models
+
+
+def display_duration(seconds, granularity=2):
+    result = []
+    intervals = (
+        ("w", 604800),
+        ("days", 86400),
+        ("hours", 3600),
+        ("min", 60),
+        ("sec", 1),
+    )
+    remaining_seconds = max(seconds or 0.0, 0.0)
+    for name, count in intervals:
+        value = int(remaining_seconds // count)
+        if value:
+            remaining_seconds -= value * count
+            if value == 1:
+                name = name.rstrip("s")
+            result.append(f"{value} {name}")
+    return ", ".join(result[:granularity])
+
+
+class CrmLeadStageDuration(models.Model):
+    _name = "crm.lead.stage.duration"
+    _description = "CRM Lead Stage Duration"
+    _order = "start_date desc, id desc"
+
+    _sql_constraints = [
+        (
+            "check_end_after_start",
+            "CHECK(end_date IS NULL OR end_date >= start_date)",
+            "The end date must be greater than or equal to start date.",
+        ),
+    ]
+
+    lead_id = fields.Many2one(
+        comodel_name="crm.lead",
+        string="Opportunity",
+        required=True,
+        ondelete="cascade",
+        index=True,
+    )
+    stage_id = fields.Many2one(
+        comodel_name="crm.stage",
+        string="Stage",
+        required=True,
+        index=True,
+    )
+    team_id = fields.Many2one(
+        comodel_name="crm.team",
+        string="Sales Team",
+        index=True,
+    )
+    user_id = fields.Many2one(
+        comodel_name="res.users",
+        string="Changed By",
+        required=True,
+        default=lambda self: self.env.user,
+        index=True,
+    )
+    start_date = fields.Datetime(
+        string="Start Date",
+        required=True,
+        default=fields.Datetime.now,
+        index=True,
+    )
+    end_date = fields.Datetime(
+        string="End Date",
+        index=True,
+    )
+    running = fields.Boolean(
+        string="Running",
+        compute="_compute_running",
+        store=True,
+    )
+    duration_seconds = fields.Float(
+        string="Duration (seconds)",
+        compute="_compute_duration",
+    )
+    duration_display = fields.Char(
+        string="Duration",
+        compute="_compute_duration",
+    )
+
+    @api.depends("end_date")
+    def _compute_running(self):
+        for record in self:
+            record.running = not bool(record.end_date)
+
+    @api.depends("start_date", "end_date")
+    def _compute_duration(self):
+        now = fields.Datetime.now()
+        for record in self:
+            duration_seconds = 0.0
+            if record.start_date:
+                stop_date = record.end_date or now
+                duration_seconds = (stop_date - record.start_date).total_seconds()
+            record.duration_seconds = max(duration_seconds, 0.0)
+            record.duration_display = (
+                display_duration(record.duration_seconds, 4)
+                if record.duration_seconds
+                else ""
+            )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if vals.get("lead_id") and not vals.get("team_id"):
+                lead = self.env["crm.lead"].browse(vals["lead_id"])
+                vals["team_id"] = lead.team_id.id
+        return super().create(vals_list)

--- a/crm_lead_stage_duration/models/crm_lead_stage_duration_report.py
+++ b/crm_lead_stage_duration/models/crm_lead_stage_duration_report.py
@@ -1,5 +1,6 @@
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+# Copyright (C) 2025-Today - KMEE (<http://www.kmee.com.br>).
 # @author Diego Paradeda <diego.paradeda@kmee.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models, tools
 

--- a/crm_lead_stage_duration/models/crm_lead_stage_duration_report.py
+++ b/crm_lead_stage_duration/models/crm_lead_stage_duration_report.py
@@ -1,0 +1,123 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+# @author Diego Paradeda <diego.paradeda@kmee.com.br>
+
+from odoo import api, fields, models, tools
+
+from .crm_lead_stage_duration import display_duration
+
+
+class CrmLeadStageDurationReport(models.Model):
+    _name = "crm.lead.stage.duration.report"
+    _description = "CRM Lead Stage Duration Report"
+    _auto = False
+
+    team_id = fields.Many2one(
+        comodel_name="crm.team",
+        string="Sales Team",
+        readonly=True,
+    )
+    stage_id = fields.Many2one(
+        comodel_name="crm.stage",
+        string="Stage",
+        readonly=True,
+    )
+    line_count = fields.Integer(
+        string="Transitions",
+        readonly=True,
+    )
+    lead_count = fields.Integer(
+        string="Opportunities",
+        readonly=True,
+    )
+    total_duration_seconds = fields.Float(
+        string="Total Duration (seconds)",
+        readonly=True,
+    )
+    avg_duration_seconds = fields.Float(
+        string="Average Duration (seconds)",
+        readonly=True,
+    )
+    avg_duration_display = fields.Char(
+        string="Average Duration",
+        compute="_compute_avg_duration_display",
+    )
+    min_duration_seconds = fields.Float(
+        string="Min Duration (seconds)",
+        readonly=True,
+    )
+    max_duration_seconds = fields.Float(
+        string="Max Duration (seconds)",
+        readonly=True,
+    )
+    closed_line_count = fields.Integer(
+        string="Closed Transitions",
+        readonly=True,
+    )
+    running_line_count = fields.Integer(
+        string="Running Transitions",
+        readonly=True,
+    )
+
+    @api.depends("avg_duration_seconds")
+    def _compute_avg_duration_display(self):
+        for record in self:
+            record.avg_duration_display = (
+                display_duration(record.avg_duration_seconds, 3)
+                if record.avg_duration_seconds
+                else ""
+            )
+
+    def init(self):
+        tools.drop_view_if_exists(self._cr, "crm_lead_stage_duration_report")
+        self._cr.execute(
+            """
+            CREATE OR REPLACE VIEW crm_lead_stage_duration_report AS (
+                WITH stage_stats AS (
+                    SELECT
+                        team_id,
+                        stage_id,
+                        COUNT(*) AS line_count,
+                        COUNT(DISTINCT lead_id) AS lead_count,
+                        SUM(CASE WHEN end_date IS NOT NULL THEN
+                            EXTRACT(EPOCH FROM (end_date - start_date))
+                        ELSE
+                            EXTRACT(EPOCH FROM (NOW() - start_date))
+                        END) AS total_duration_seconds,
+                        AVG(CASE WHEN end_date IS NOT NULL THEN
+                            EXTRACT(EPOCH FROM (end_date - start_date))
+                        ELSE
+                            EXTRACT(EPOCH FROM (NOW() - start_date))
+                        END) AS avg_duration_seconds,
+                        MIN(CASE WHEN end_date IS NOT NULL THEN
+                            EXTRACT(EPOCH FROM (end_date - start_date))
+                        ELSE
+                            EXTRACT(EPOCH FROM (NOW() - start_date))
+                        END) AS min_duration_seconds,
+                        MAX(CASE WHEN end_date IS NOT NULL THEN
+                            EXTRACT(EPOCH FROM (end_date - start_date))
+                        ELSE
+                            EXTRACT(EPOCH FROM (NOW() - start_date))
+                        END) AS max_duration_seconds,
+                        COUNT(CASE WHEN end_date IS NOT NULL THEN 1 END) AS closed_line_count,
+                        COUNT(CASE WHEN end_date IS NULL THEN 1 END) AS running_line_count
+                    FROM crm_lead_stage_duration
+                    WHERE start_date IS NOT NULL
+                    GROUP BY team_id, stage_id
+                )
+                SELECT
+                    ROW_NUMBER() OVER () AS id,
+                    team_id,
+                    stage_id,
+                    line_count,
+                    lead_count,
+                    total_duration_seconds,
+                    avg_duration_seconds,
+                    min_duration_seconds,
+                    max_duration_seconds,
+                    closed_line_count,
+                    running_line_count
+                FROM stage_stats
+                WHERE line_count > 0
+            )
+            """
+        )

--- a/crm_lead_stage_duration/security/ir.model.access.csv
+++ b/crm_lead_stage_duration/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_crm_lead_stage_duration_user,crm.lead.stage.duration.user,model_crm_lead_stage_duration,base.group_user,1,0,0,0
+access_crm_lead_stage_duration_manager,crm.lead.stage.duration.manager,model_crm_lead_stage_duration,sales_team.group_sale_manager,1,1,1,1
+access_crm_lead_stage_duration_report_user,crm.lead.stage.duration.report.user,model_crm_lead_stage_duration_report,base.group_user,1,0,0,0

--- a/crm_lead_stage_duration/views/crm_lead_stage_duration_views.xml
+++ b/crm_lead_stage_duration/views/crm_lead_stage_duration_views.xml
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_crm_lead_stage_duration_tree" model="ir.ui.view">
+        <field name="name">crm.lead.stage.duration.tree</field>
+        <field name="model">crm.lead.stage.duration</field>
+        <field name="arch" type="xml">
+            <tree create="false" delete="false" edit="false">
+                <field name="lead_id" />
+                <field name="stage_id" />
+                <field name="team_id" />
+                <field name="start_date" />
+                <field name="end_date" />
+                <field name="duration_display" />
+                <field name="duration_seconds" />
+                <field name="running" />
+                <field name="user_id" />
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_crm_lead_stage_duration_search" model="ir.ui.view">
+        <field name="name">crm.lead.stage.duration.search</field>
+        <field name="model">crm.lead.stage.duration</field>
+        <field name="arch" type="xml">
+            <search string="CRM Stage Durations">
+                <field name="lead_id" />
+                <field name="stage_id" />
+                <field name="team_id" />
+                <field name="user_id" />
+                <filter
+                    name="filter_running"
+                    string="Running"
+                    domain="[('running', '=', True)]"
+                />
+                <filter
+                    name="filter_closed"
+                    string="Closed"
+                    domain="[('running', '=', False)]"
+                />
+                <group expand="0" string="Group By">
+                    <filter
+                        name="group_team"
+                        string="Sales Team"
+                        domain="[]"
+                        context="{'group_by': 'team_id'}"
+                    />
+                    <filter
+                        name="group_stage"
+                        string="Stage"
+                        domain="[]"
+                        context="{'group_by': 'stage_id'}"
+                    />
+                    <filter
+                        name="group_user"
+                        string="Changed By"
+                        domain="[]"
+                        context="{'group_by': 'user_id'}"
+                    />
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <record id="action_crm_lead_stage_duration" model="ir.actions.act_window">
+        <field name="name">Stage Duration Records</field>
+        <field name="res_model">crm.lead.stage.duration</field>
+        <field name="view_mode">tree</field>
+        <field name="domain">[('lead_id.type', '=', 'opportunity')]</field>
+        <field name="search_view_id" ref="view_crm_lead_stage_duration_search" />
+    </record>
+
+    <record id="view_crm_lead_stage_duration_report_tree" model="ir.ui.view">
+        <field name="name">crm.lead.stage.duration.report.tree</field>
+        <field name="model">crm.lead.stage.duration.report</field>
+        <field name="arch" type="xml">
+            <tree create="false" edit="false" delete="false">
+                <field name="team_id" />
+                <field name="stage_id" />
+                <field name="line_count" />
+                <field name="lead_count" />
+                <field name="avg_duration_display" />
+                <field name="total_duration_seconds" />
+                <field name="avg_duration_seconds" />
+                <field name="min_duration_seconds" />
+                <field name="max_duration_seconds" />
+                <field name="closed_line_count" />
+                <field name="running_line_count" />
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_crm_lead_stage_duration_report_pivot" model="ir.ui.view">
+        <field name="name">crm.lead.stage.duration.report.pivot</field>
+        <field name="model">crm.lead.stage.duration.report</field>
+        <field name="arch" type="xml">
+            <pivot string="CRM Stage Duration Analysis">
+                <field name="team_id" type="row" />
+                <field name="stage_id" type="row" />
+                <field name="lead_count" type="measure" />
+                <field name="line_count" type="measure" />
+                <field name="avg_duration_seconds" type="measure" />
+                <field name="total_duration_seconds" type="measure" />
+            </pivot>
+        </field>
+    </record>
+
+    <record id="view_crm_lead_stage_duration_report_graph" model="ir.ui.view">
+        <field name="name">crm.lead.stage.duration.report.graph</field>
+        <field name="model">crm.lead.stage.duration.report</field>
+        <field name="arch" type="xml">
+            <graph string="CRM Stage Duration Analysis" type="bar">
+                <field name="team_id" />
+                <field name="stage_id" />
+                <field name="avg_duration_seconds" type="measure" />
+            </graph>
+        </field>
+    </record>
+
+    <record id="view_crm_lead_stage_duration_report_kanban" model="ir.ui.view">
+        <field name="name">crm.lead.stage.duration.report.kanban</field>
+        <field name="model">crm.lead.stage.duration.report</field>
+        <field name="arch" type="xml">
+            <kanban
+                class="o_kanban_small_column"
+                create="false"
+                edit="false"
+                default_group_by="team_id"
+            >
+                <field name="team_id" />
+                <field name="stage_id" />
+                <field name="lead_count" />
+                <field name="line_count" />
+                <field name="avg_duration_display" />
+                <field name="running_line_count" />
+                <field name="closed_line_count" />
+                <templates>
+                    <t t-name="kanban-box">
+                        <div class="oe_kanban_card oe_kanban_global_click">
+                            <div class="oe_kanban_content">
+                                <div class="o_kanban_record_title">
+                                    <strong><field name="team_id" /></strong>
+                                </div>
+                                <div class="o_kanban_record_subtitle">
+                                    <field name="stage_id" />
+                                </div>
+                                <div class="mt8">
+                                    <div>
+                                        <strong>Average:</strong>
+                                        <field name="avg_duration_display" />
+                                    </div>
+                                    <div>
+                                        <strong>Opportunities:</strong>
+                                        <field name="lead_count" />
+                                    </div>
+                                    <div>
+                                        <strong>Transitions:</strong>
+                                        <field name="line_count" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
+    <record id="view_crm_lead_stage_duration_report_search" model="ir.ui.view">
+        <field name="name">crm.lead.stage.duration.report.search</field>
+        <field name="model">crm.lead.stage.duration.report</field>
+        <field name="arch" type="xml">
+            <search string="CRM Stage Duration Report">
+                <field name="team_id" />
+                <field name="stage_id" />
+                <group expand="0" string="Group By">
+                    <filter
+                        name="group_report_team"
+                        string="Sales Team"
+                        context="{'group_by': 'team_id'}"
+                    />
+                    <filter
+                        name="group_report_stage"
+                        string="Stage"
+                        context="{'group_by': 'stage_id'}"
+                    />
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <record id="action_crm_lead_stage_duration_report" model="ir.actions.act_window">
+        <field name="name">Stage Duration Analysis</field>
+        <field name="res_model">crm.lead.stage.duration.report</field>
+        <field name="view_mode">graph,pivot,kanban,tree</field>
+        <field
+            name="search_view_id"
+            ref="view_crm_lead_stage_duration_report_search"
+        />
+        <field name="context">{'search_default_group_report_team': 1}</field>
+    </record>
+
+    <menuitem
+        id="menu_crm_lead_stage_duration_report"
+        name="Stage Duration Analysis"
+        parent="crm.crm_menu_report"
+        action="action_crm_lead_stage_duration_report"
+        sequence="45"
+    />
+
+    <menuitem
+        id="menu_crm_lead_stage_duration_records"
+        name="Stage Duration Records"
+        parent="crm.crm_menu_report"
+        action="action_crm_lead_stage_duration"
+        sequence="46"
+        groups="sales_team.group_sale_manager"
+    />
+</odoo>

--- a/crm_lead_stage_duration/views/crm_lead_views.xml
+++ b/crm_lead_stage_duration/views/crm_lead_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="crm_lead_form_view_stage_duration" model="ir.ui.view">
+        <field name="name">crm.lead.form.stage.duration</field>
+        <field name="model">crm.lead</field>
+        <field name="inherit_id" ref="crm.crm_lead_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//notebook" position="inside">
+                <page string="Stage Durations" name="stage_durations">
+                    <group>
+                        <field name="current_stage_total_duration" readonly="1" />
+                    </group>
+                    <field name="stage_duration_ids" readonly="1" nolabel="1">
+                        <tree create="false" delete="false" edit="false">
+                            <field name="stage_id" />
+                            <field name="team_id" />
+                            <field name="start_date" />
+                            <field name="end_date" />
+                            <field name="duration_display" />
+                            <field name="duration_seconds" />
+                            <field name="running" />
+                            <field name="user_id" />
+                        </tree>
+                    </field>
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/setup/crm_lead_stage_duration/setup.py
+++ b/setup/crm_lead_stage_duration/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=["setuptools-odoo"],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Add `crm_lead_stage_duration` module to track time spent by a `crm.lead` in each `crm.stage`.

This module creates a historical record (`crm.lead.stage.duration`) for each lead, closing the previous entry and opening a new one whenever the `stage_id` changes. It includes a dedicated tab on the lead form and a reporting menu under CRM > Reporting for detailed analysis of stage durations.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-110a34fe-8e26-4cca-89ec-e9982a811878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-110a34fe-8e26-4cca-89ec-e9982a811878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

