### PR TITLE
[MIG] sale_freight_distribution: Migration to 18.0

### DIFF
--- a/sale_freight_distribution/README.rst
+++ b/sale_freight_distribution/README.rst
@@ -1,0 +1,32 @@
+=========================
+Sale Freight Distribution
+=========================
+
+sale_freight_distribution
+
+Purpose
+=======
+
+This module does this and that...
+
+Explain the use case.
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Go to ...
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Go to ...
+
+
+How to test
+===========
+
+...

--- a/sale_freight_distribution/__init__.py
+++ b/sale_freight_distribution/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_freight_distribution/__manifest__.py
+++ b/sale_freight_distribution/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2025 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Sale Freight Distribution",
+    "summary": "Distribute freight costs proportionally across sale order lines",
+    "version": "18.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "KMEE, Odoo Community Association (OCA)",
+    "maintainers": ["mileo"],
+    "website": "https://github.com/KMEE/kmee-odoo-addons",
+    "depends": [
+        "l10n_br_sale",
+    ],
+    "data": [],
+    "demo": [],
+}

--- a/sale_freight_distribution/models/__init__.py
+++ b/sale_freight_distribution/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/sale_freight_distribution/models/sale_order.py
+++ b/sale_freight_distribution/models/sale_order.py
@@ -1,0 +1,51 @@
+# Copyright 2025 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class SaleOrder(models.Model):
+
+    _inherit = "sale.order"
+
+    def write(self, vals):
+        res = super().write(vals)
+        self._distribute_shipping_cost()
+        return res
+
+    def _is_freight_eligible_line(self, line):
+        """Check if a sale order line is eligible for freight distribution.
+
+        In Odoo 18, the product type 'product' (storable) was removed.
+        Storable products are now type='consu' with is_storable=True.
+        We consider all non-service products as freight-eligible.
+        """
+        return line.product_id and line.product_id.type != "service"
+
+    def _distribute_shipping_cost(self):
+        for order in self:
+            if not order.order_line or not order.amount_freight_value:
+                continue
+            eligible_lines = order.order_line.filtered(
+                self._is_freight_eligible_line
+            )
+            total_wo_delivery = sum(
+                line.price_subtotal for line in eligible_lines
+            )
+            if total_wo_delivery == 0:
+                continue
+            for line in eligible_lines:
+                proportion = line.price_subtotal / total_wo_delivery
+                line.freight_value = (
+                    order.amount_freight_value * proportion / line.product_uom_qty
+                )
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    def unlink(self):
+        orders = self.mapped("order_id")
+        res = super().unlink()
+        orders._distribute_shipping_cost()
+        return res

--- a/sale_freight_distribution/readme/CONTRIBUTORS.md
+++ b/sale_freight_distribution/readme/CONTRIBUTORS.md
@@ -1,0 +1,2 @@
+- [KMEE](https://www.kmee.com.br):
+  - Luis Felipe Mileo <mileo@kmee.com.br>

--- a/sale_freight_distribution/readme/DESCRIPTION.md
+++ b/sale_freight_distribution/readme/DESCRIPTION.md
@@ -1,0 +1,7 @@
+This module distributes the freight cost of a sale order proportionally
+across its order lines based on each line's subtotal value.
+
+Only non-service product lines are considered for freight distribution.
+The freight value per unit is calculated as:
+
+    line_freight = (order_freight * line_subtotal / total_subtotal) / line_qty


### PR DESCRIPTION
## Summary
- Migrated `sale_freight_distribution` from 14.0 to 18.0
- Updated manifest version to 18.0.1.0.0
- Applied all necessary code adaptations for Odoo 18.0 compatibility

## Migration details
- Source branch: 14.0
- Target branch: 18.0
- Module dependencies: l10n_br_sale (updated from sale, since fields amount_freight_value and freight_value come from l10n-brazil)

## Changes
- **Manifest**: Updated version to 18.0.1.0.0, improved summary, added maintainers
- **Product type filter**: Replaced `product_id.type == "product"` with `product_id.type != "service"` (Odoo 18 removed the "product" type; storable products are now `type='consu'` with `is_storable=True`)
- **Code refactor**: Extracted `_is_freight_eligible_line()` method for extensibility, used `filtered()` for cleaner line selection
- **Dependencies**: Changed from `sale` to `l10n_br_sale` since the module uses Brazilian fiscal freight fields
- **Docs**: Added `readme/DESCRIPTION.md` and `readme/CONTRIBUTORS.md`

## Test plan
- [ ] Install module on Odoo 18.0 instance
- [ ] Verify freight distribution across sale order lines
- [ ] Run module tests