### PR TITLE
[MIG] sale_order_qty_available_today: Migration to 18.0

### DIFF
--- a/sale_order_qty_available_today/README.rst
+++ b/sale_order_qty_available_today/README.rst
@@ -1,0 +1,32 @@
+===================
+Sale Order Free Qty
+===================
+
+Sale Order Free Qty
+
+Purpose
+=======
+
+This module does this and that...
+
+Explain the use case.
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Go to ...
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Go to ...
+
+
+How to test
+===========
+
+...

--- a/sale_order_qty_available_today/__manifest__.py
+++ b/sale_order_qty_available_today/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2025 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Sale Order Qty Available Today",
+    "summary": "Display available quantity on sale order lines",
+    "version": "18.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "KMEE",
+    "website": "https://github.com/KMEE/kmee-odoo-addons",
+    "depends": ["sale_stock"],
+    "data": [
+        "views/sale_order_line.xml",
+    ],
+    "maintainers": ["mileo"],
+}

--- a/sale_order_qty_available_today/readme/DESCRIPTION.md
+++ b/sale_order_qty_available_today/readme/DESCRIPTION.md
@@ -1,0 +1,5 @@
+This module makes the **Qty Available Today** field visible on sale order
+line forms. By default, Odoo's `sale_stock` module includes this field but
+keeps it hidden (used only internally by the forecast widget). This module
+exposes the field so users can quickly see current stock availability
+directly on the order line.

--- a/sale_order_qty_available_today/views/sale_order_line.xml
+++ b/sale_order_qty_available_today/views/sale_order_line.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2025 KMEE
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="sale_order_line_form_view">
+        <field name="model">sale.order</field>
+        <field
+            name="inherit_id"
+            ref="sale_stock.view_order_form_inherit_sale_stock_qty"
+        />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='order_line']/form//field[@name='qty_available_today']"
+                position="attributes"
+            >
+                <attribute name="invisible">0</attribute>
+                <attribute name="string">Qty Available Today</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- Migrated `sale_order_qty_available_today` from 14.0 to 18.0
- Updated manifest version to 18.0.1.0.0
- Updated view XML to inherit from `sale_stock.view_order_form_inherit_sale_stock_qty` instead of `sale.view_order_form`, making the already-existing `qty_available_today` field visible (it is hidden by default in Odoo 18's sale_stock module)
- Added `readme/DESCRIPTION.md`

## Migration details
- Source branch: 14.0
- Target branch: 18.0
- Module dependencies: sale_stock
- In Odoo 18, `qty_available_today` is already defined on `sale.order.line` by `sale_stock` and present in the form view as `invisible="1"` (used by the forecast widget). This module simply makes it visible.

## Test plan
- [ ] Install module on Odoo 18.0 instance
- [ ] Verify `Qty Available Today` field is visible on sale order line form
- [ ] Confirm the forecast widget (`qty_at_date_widget`) still works correctly
- [ ] Run module tests