### PR TITLE
[MIG] sale_margin_product_cost_security: Migration to 18.0

### DIFF
--- a/sale_margin_product_cost_security/__manifest__.py
+++ b/sale_margin_product_cost_security/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Sale Product Cost Security",
+    "summary": "Extends product cost security to sale margin purchase price field",
+    "version": "18.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "KMEE, Odoo Community Association (OCA)",
+    "maintainers": ["mileo"],
+    "website": "https://github.com/KMEE/kmee-odoo-addons",
+    "depends": ["sale_margin", "product_cost_security"],
+    "data": [
+        "views/sale_order_line_views.xml",
+    ],
+    "demo": [],
+}

--- a/sale_margin_product_cost_security/readme/CONFIGURE.md
+++ b/sale_margin_product_cost_security/readme/CONFIGURE.md
@@ -1,0 +1,1 @@
+This module does not need configuration.

--- a/sale_margin_product_cost_security/readme/CONTRIBUTORS.md
+++ b/sale_margin_product_cost_security/readme/CONTRIBUTORS.md
@@ -1,0 +1,2 @@
+- [KMEE](https://www.kmee.com.br):
+  - Tiago Amaral <tiago.amaral@kmee.com.br>

--- a/sale_margin_product_cost_security/readme/DESCRIPTION.md
+++ b/sale_margin_product_cost_security/readme/DESCRIPTION.md
@@ -1,0 +1,3 @@
+This module extends the functionality of the product_cost_security module to the purchase_price field of the sale_margin module.
+
+When the user does not belong to the group product_cost_group, he cannot see the "Cost" field in the Sale Order Line view.

--- a/sale_margin_product_cost_security/readme/USAGE.md
+++ b/sale_margin_product_cost_security/readme/USAGE.md
@@ -1,0 +1,6 @@
+To use this module you need to:
+
+1. Go to product form view logged with this user and you will see the
+   standard_price field.
+2. Go to sale order line form view logged with this user and you will see the
+   purchase_price field.

--- a/sale_margin_product_cost_security/views/sale_order_line_views.xml
+++ b/sale_margin_product_cost_security/views/sale_order_line_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2024 KMEE
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="sale_margin_sale_order_line" model="ir.ui.view">
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale_margin.sale_margin_sale_order_line" />
+        <field name="arch" type="xml">
+            <field name="purchase_price" position="attributes">
+                <attribute
+                    name="groups"
+                >product_cost_security.group_product_cost</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- Migrated `sale_margin_product_cost_security` from 14.0 to 18.0
- Updated manifest version to 18.0.1.0.0
- Improved summary in manifest
- Added maintainers field
- Converted readme files from RST to Markdown
- Removed auto-generated static files (README.rst, index.html)

## Migration details
- Source branch: 14.0
- Target branch: 18.0
- Module dependencies: `sale_margin`, `product_cost_security` (OCA)
- No Python code changes needed (module has no Python logic)
- XML view is compatible with Odoo 18 (only adds `groups` attribute to existing field)

## Test plan
- [ ] Install module on Odoo 18.0 instance with `sale_margin` and `product_cost_security`
- [ ] Verify that users WITHOUT `group_product_cost` cannot see the `purchase_price` (Cost) field in Sale Order Lines
- [ ] Verify that users WITH `group_product_cost` can see the `purchase_price` field normally