### PR TITLE
[MIG] sale_order_qty_available_today: Migration to 16.0

### DIFF
--- a/sale_order_qty_available_today/README.rst
+++ b/sale_order_qty_available_today/README.rst
@@ -1,0 +1,32 @@
+===================
+Sale Order Free Qty
+===================
+
+Sale Order Free Qty
+
+Purpose
+=======
+
+This module does this and that...
+
+Explain the use case.
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Go to ...
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Go to ...
+
+
+How to test
+===========
+
+...

--- a/sale_order_qty_available_today/__manifest__.py
+++ b/sale_order_qty_available_today/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2025 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Sale Order Qty Available Today",
+    "summary": """Sale Order Free Qty""",
+    "version": "16.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "KMEE",
+    "website": "https://github.com/KMEE/kmee-odoo-addons",
+    "depends": ["sale_stock"],
+    "data": [
+        "views/sale_order_line.xml",
+    ],
+    "demo": [],
+}

--- a/sale_order_qty_available_today/views/sale_order_line.xml
+++ b/sale_order_qty_available_today/views/sale_order_line.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2025 KMEE
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="sale_order_line_form_view">
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='order_line']/form//div[@name='ordered_qty']"
+                position="after"
+            >
+                <field name="qty_available_today" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- Migrated `sale_order_qty_available_today` from 14.0 to 16.0

## Migration details
- Source branch: 14.0
- Target branch: 16.0

## Test plan
- [ ] Install module on Odoo 16.0 instance
- [ ] Run module tests