### PR TITLE
[18.0][MIG] sale_freight_distribution

### DIFF
--- a/sale_freight_distribution/README.rst
+++ b/sale_freight_distribution/README.rst
@@ -1,0 +1,32 @@
+=========================
+Sale Freight Distribution
+=========================
+
+sale_freight_distribution
+
+Purpose
+=======
+
+This module does this and that...
+
+Explain the use case.
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Go to ...
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Go to ...
+
+
+How to test
+===========
+
+...

--- a/sale_freight_distribution/__init__.py
+++ b/sale_freight_distribution/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_freight_distribution/__manifest__.py
+++ b/sale_freight_distribution/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2025 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Sale Freight Distribution",
+    "summary": """sale_freight_distribution""",
+    "version": "14.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "KMEE",
+    "website": "https://github.com/KMEE/kmee-odoo-addons",
+    "depends": [
+        "sale",
+    ],
+    "data": [],
+    "demo": [],
+}

--- a/sale_freight_distribution/__manifest__.py
+++ b/sale_freight_distribution/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Sale Freight Distribution",
     "summary": "Distributes freight cost proportionally across sale order lines",
-    "version": "16.0.1.0.0",
+    "version": "18.0.1.0.0",
     "license": "AGPL-3",
     "author": "KMEE, Odoo Community Association (OCA)",
     "maintainers": ["mileo"],

--- a/sale_freight_distribution/__manifest__.py
+++ b/sale_freight_distribution/__manifest__.py
@@ -3,13 +3,14 @@
 
 {
     "name": "Sale Freight Distribution",
-    "summary": """sale_freight_distribution""",
-    "version": "14.0.1.0.0",
+    "summary": "Distributes freight cost proportionally across sale order lines",
+    "version": "16.0.1.0.0",
     "license": "AGPL-3",
-    "author": "KMEE",
+    "author": "KMEE, Odoo Community Association (OCA)",
+    "maintainers": ["mileo"],
     "website": "https://github.com/KMEE/kmee-odoo-addons",
     "depends": [
-        "sale",
+        "l10n_br_sale",
     ],
     "data": [],
     "demo": [],

--- a/sale_freight_distribution/models/__init__.py
+++ b/sale_freight_distribution/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/sale_freight_distribution/models/sale_order.py
+++ b/sale_freight_distribution/models/sale_order.py
@@ -1,0 +1,43 @@
+# Copyright 2025 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class SaleOrder(models.Model):
+
+    _inherit = "sale.order"
+
+    def write(self, vals):
+        res = super().write(vals)
+        self._distribute_shipping_cost()
+        return res
+
+    def _distribute_shipping_cost(self):
+        for order in self:
+            if not order.order_line or not order.amount_freight_value:
+                continue
+            total_wo_delivery = sum(
+                line.price_subtotal
+                for line in order.order_line
+                if line.product_id.type == "product"
+            )
+            if total_wo_delivery == 0:
+                continue
+            for line in order.order_line:
+                if line.product_id.type != "product":
+                    continue
+                proportion = line.price_subtotal / total_wo_delivery
+                line.freight_value = (
+                    order.amount_freight_value * proportion / line.product_uom_qty
+                )
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    def unlink(self):
+        orders = self.mapped("order_id")
+        res = super().unlink()
+        orders._distribute_shipping_cost()
+        return res

--- a/sale_freight_distribution/models/sale_order.py
+++ b/sale_freight_distribution/models/sale_order.py
@@ -17,16 +17,15 @@ class SaleOrder(models.Model):
         for order in self:
             if not order.order_line or not order.amount_freight_value:
                 continue
+            product_lines = order.order_line.filtered(
+                lambda l: l.product_id and l.product_id.type != "service"
+            )
             total_wo_delivery = sum(
-                line.price_subtotal
-                for line in order.order_line
-                if line.product_id.type == "product"
+                line.price_subtotal for line in product_lines
             )
             if total_wo_delivery == 0:
                 continue
-            for line in order.order_line:
-                if line.product_id.type != "product":
-                    continue
+            for line in product_lines:
                 proportion = line.price_subtotal / total_wo_delivery
                 line.freight_value = (
                     order.amount_freight_value * proportion / line.product_uom_qty

--- a/sale_freight_distribution/readme/DESCRIPTION.md
+++ b/sale_freight_distribution/readme/DESCRIPTION.md
@@ -1,0 +1,6 @@
+This module distributes the freight cost (amount_freight_value) from a sale order
+proportionally across its order lines based on each line's subtotal relative to
+the total of storable product lines.
+
+When the sale order is saved or a line is removed, the freight is automatically
+recalculated and distributed to each line's freight_value field.

--- a/setup/sale_freight_distribution/odoo/addons/sale_freight_distribution
+++ b/setup/sale_freight_distribution/odoo/addons/sale_freight_distribution
@@ -1,0 +1,1 @@
+../../../../sale_freight_distribution

--- a/setup/sale_freight_distribution/setup.py
+++ b/setup/sale_freight_distribution/setup.py
@@ -1,0 +1,2 @@
+import setuptools
+setuptools.setup(setup_requires=['setuptools-odoo'], odoo_addon=True)


### PR DESCRIPTION
## Summary
- Migrates `sale_freight_distribution` module from 16.0 to 18.0 using oca-port
- Adapts product type filtering for Odoo 18.0: replaces `type == "product"` (removed in 18.0) with `type != "service"` to correctly filter storable/consumable product lines
- Keeps `l10n_br_sale` dependency for `amount_freight_value` and `freight_value` fields
- Module distributes freight cost proportionally across sale order lines based on each line's subtotal

## Test plan
- [ ] Install module on an 18.0 instance with `l10n_br_sale`
- [ ] Create a sale order with multiple product lines (storable/consumable) and set a freight value
- [ ] Verify freight is distributed proportionally across non-service lines
- [ ] Remove a line and verify freight is recalculated
- [ ] Add a service line and verify it is excluded from freight distribution