### PR TITLE
[18.0][MIG] sale_commission_period_26

### DIFF
--- a/sale_commission_period_26/__init__.py
+++ b/sale_commission_period_26/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_commission_period_26/__manifest__.py
+++ b/sale_commission_period_26/__manifest__.py
@@ -9,7 +9,7 @@
     "license": "AGPL-3",
     "author": "KMEE, Odoo Community Association (OCA)",
     "website": "https://github.com/KMEE/kmee-odoo-addons",
-    "depends": ["commission"],
+    "depends": ["commission_oca"],
     "installable": True,
     "maintainers": ["mileo"],
 }

--- a/sale_commission_period_26/__manifest__.py
+++ b/sale_commission_period_26/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2025 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Sale Commission Period 26",
+    "version": "18.0.1.0.0",
+    "summary": "Allow the commission to close from the 26th to the 25th of each month.",
+    "category": "Sales",
+    "license": "AGPL-3",
+    "author": "KMEE, Odoo Community Association (OCA)",
+    "website": "https://github.com/KMEE/kmee-odoo-addons",
+    "depends": ["commission"],
+    "installable": True,
+    "maintainers": ["mileo"],
+}

--- a/sale_commission_period_26/models/__init__.py
+++ b/sale_commission_period_26/models/__init__.py
@@ -1,0 +1,2 @@
+from . import res_partner
+from . import sale_commission_make_settle

--- a/sale_commission_period_26/models/res_partner.py
+++ b/sale_commission_period_26/models/res_partner.py
@@ -1,0 +1,15 @@
+# Copyright 2025 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    settlement = fields.Selection(
+        selection_add=[
+            ("vinte_seis", _("26 até 25")),
+        ],
+        ondelete={"vinte_seis": "set default"},
+    )

--- a/sale_commission_period_26/models/sale_commission_make_settle.py
+++ b/sale_commission_period_26/models/sale_commission_make_settle.py
@@ -1,0 +1,26 @@
+# Copyright 2025 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from datetime import date
+
+from dateutil.relativedelta import relativedelta
+
+from odoo import models
+
+
+class SaleCommissionMakeSettle(models.TransientModel):
+    _inherit = "commission.make.settle"
+
+    def _get_period_start(self, agent, date_to):
+        if agent.settlement == "vinte_seis" and date_to:
+            if date_to.day >= 26:
+                return date(year=date_to.year, month=date_to.month, day=26)
+            prev_month = date_to - relativedelta(months=1)
+            return date(year=prev_month.year, month=prev_month.month, day=26)
+        return super()._get_period_start(agent, date_to)
+
+    def _get_next_period_date(self, agent, current_date):
+        if agent.settlement == "vinte_seis" and current_date:
+            next_month = current_date + relativedelta(months=1)
+            return date(year=next_month.year, month=next_month.month, day=26)
+        return super()._get_next_period_date(agent, current_date)

--- a/sale_commission_period_26/readme/CONTRIBUTORS.md
+++ b/sale_commission_period_26/readme/CONTRIBUTORS.md
@@ -1,0 +1,1 @@
+- Luis Felipe Mileo <mileo@kmee.com.br> (https://kmee.com.br)

--- a/sale_commission_period_26/readme/CREDITS.md
+++ b/sale_commission_period_26/readme/CREDITS.md
@@ -1,0 +1,3 @@
+The development of this module has been financially supported by:
+
+- KMEE

--- a/sale_commission_period_26/readme/DESCRIPTION.md
+++ b/sale_commission_period_26/readme/DESCRIPTION.md
@@ -1,0 +1,1 @@
+Allow the commission to close from the 26th to the 25th of each month.

--- a/setup/sale_commission_period_26/odoo/addons/sale_commission_period_26
+++ b/setup/sale_commission_period_26/odoo/addons/sale_commission_period_26
@@ -1,0 +1,1 @@
+../../../../sale_commission_period_26

--- a/setup/sale_commission_period_26/setup.py
+++ b/setup/sale_commission_period_26/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
## Summary
- Migrate sale_commission_period_26 from 16.0 to 18.0
- Simplify super() calls by removing `inspect.signature` workaround
- Update version to 18.0.1.0.0
- Add maintainers field

## Test plan
- [ ] Install module on 18.0 instance with `commission` module
- [ ] Verify `vinte_seis` settlement option appears on partner form
- [ ] Verify commission settlement correctly uses 26th-25th period