### PR TITLE
[FIX] Fix manifest versions breaking CI (14.0/15.0→16.0)

### DIFF
--- a/helpdesk_mgmt_sla_safety/__manifest__.py
+++ b/helpdesk_mgmt_sla_safety/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "Helpdesk Management SLA Safety Date",
     "summary": "Add safety date concept to SLA deadlines",
-    "version": "14.0.1.0.0",
+    "version": "16.0.1.0.0",
     "category": "After-Sales",
     "author": "Your Company",
     "website": "https://github.com/KMEE/kmee-odoo-addons",

--- a/hr_overtime_report_action_pdf/__manifest__.py
+++ b/hr_overtime_report_action_pdf/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "HR Overtime Report Action PDF",
-    "version": "15.0.1.0.0",
+    "version": "16.0.1.0.0",
     "summary": "Exporta PDF via menu Ações na list view hr.attendance.overtime",
     "author": "Seu Nome",
     "category": "Human Resources",


### PR DESCRIPTION
## Summary
Fix incorrect version numbers in manifests that break CI:
- `helpdesk_mgmt_sla_safety`: 14.0.1.0.0 → 16.0.1.0.0
- `hr_overtime_report_action_pdf`: 15.0.1.0.0 → 16.0.1.0.0

These cause `pyproject-dependencies` to generate `odoo14-addon-*` and `odoo<15.1dev` entries in `test-requirements.txt`, which pip cannot resolve in the 16.0 CI container.