### PR TITLE
[FIX] l10n_br_hr_vacation: correção fiscal de férias, 13º e rescisão

### DIFF
--- a/l10n_br_hr_vacation/__manifest__.py
+++ b/l10n_br_hr_vacation/__manifest__.py
@@ -17,6 +17,7 @@
         "data/hr_leave_type_data.xml",
         "data/hr_salary_rule_ferias_data.xml",
         "data/hr_salary_rule_13_data.xml",
+        "data/hr_salary_rule_rescisao_data.xml",
         "data/hr_payroll_structure_data.xml",
         "views/hr_payslip_views.xml",
     ],

--- a/l10n_br_hr_vacation/data/hr_payroll_structure_data.xml
+++ b/l10n_br_hr_vacation/data/hr_payroll_structure_data.xml
@@ -10,10 +10,12 @@
                 ref('hr_rule_ferias'),
                 ref('hr_rule_adicional_ferias'),
                 ref('hr_rule_abono_pecuniario'),
+                ref('hr_rule_adicional_abono'),
                 ref('hr_rule_gross_ferias'),
                 ref('hr_rule_inss_ferias'),
                 ref('hr_rule_base_irrf_ferias'),
                 ref('hr_rule_irrf_ferias'),
+                ref('hr_rule_fgts_ferias'),
                 ref('hr_rule_net_ferias'),
             ])]"
         />
@@ -32,7 +34,7 @@
         />
     </record>
 
-    <!-- Estrutura: 13º Salário — 2ª Parcela (com INSS e IRRF) -->
+    <!-- Estrutura: 13º Salário — 2ª Parcela (com INSS, IRRF, FGTS e dedução da 1ª) -->
     <record id="structure_13_segunda_parcela" model="hr.payroll.structure">
         <field name="name">13º Salário - 2ª Parcela</field>
         <field name="code">13_2PARCELA</field>
@@ -44,6 +46,8 @@
                 ref('hr_rule_inss_13'),
                 ref('hr_rule_base_irrf_13'),
                 ref('hr_rule_irrf_13'),
+                ref('hr_rule_fgts_13'),
+                ref('hr_rule_desconto_adiantamento_13'),
                 ref('hr_rule_net_13'),
             ])]"
         />
@@ -61,22 +65,32 @@
                 ref('hr_rule_inss_13'),
                 ref('hr_rule_base_irrf_13'),
                 ref('hr_rule_irrf_13'),
+                ref('hr_rule_fgts_13'),
                 ref('hr_rule_net_13'),
             ])]"
         />
     </record>
 
-    <!-- Estrutura: Rescisão (inclui 13º proporcional) -->
+    <!-- Estrutura: Rescisão (verbas rescisórias seguras — ver rescisão data) -->
     <record id="structure_rescisao" model="hr.payroll.structure">
         <field name="name">Rescisão</field>
         <field name="code">RESCISAO</field>
         <field
             name="rule_ids"
             eval="[(6, 0, [
-                ref('l10n_br_hr_payroll.hr_rule_salario_base'),
-                ref('l10n_br_hr_payroll.hr_rule_gross'),
+                ref('hr_rule_saldo_salario'),
                 ref('hr_rule_decimo_rescisao'),
-                ref('l10n_br_hr_payroll.hr_rule_net'),
+                ref('hr_rule_ferias_indenizadas'),
+                ref('hr_rule_adicional_ferias_indenizadas'),
+                ref('hr_rule_inss_rescisao'),
+                ref('hr_rule_inss_13_rescisao'),
+                ref('hr_rule_base_irrf_rescisao'),
+                ref('hr_rule_base_irrf_13_rescisao'),
+                ref('hr_rule_irrf_rescisao'),
+                ref('hr_rule_irrf_13_rescisao'),
+                ref('hr_rule_fgts_rescisao'),
+                ref('hr_rule_fgts_13_rescisao'),
+                ref('hr_rule_net_rescisao'),
             ])]"
         />
     </record>

--- a/l10n_br_hr_vacation/data/hr_salary_rule_13_data.xml
+++ b/l10n_br_hr_vacation/data/hr_salary_rule_13_data.xml
@@ -25,7 +25,12 @@
         <field name="condition_select">none</field>
         <field name="amount_select">code</field>
         <field name="amount_python_compute">
-result = tools.br.round_money(contract.wage * 0.5)
+# 1ª parcela = 50% do 13º projetado para 31/12 (proporcional aos avos).
+# Para empregado de ano cheio, avos=12 => 50% do salário.
+# Para admitido no meio do ano, proporcional aos meses trabalhados.
+ref = payslip.date_to + tools.relativedelta(month=12, day=31)
+avos = tools.br.calc_decimo_avos(contract.date_start, ref)
+result = tools.br.round_money(contract.wage * avos / 12 * 0.5)
         </field>
     </record>
 
@@ -134,6 +139,45 @@ result = not employee.l10n_br_molestia_grave
         <field name="amount_select">code</field>
         <field name="amount_python_compute">
 result = tools.br.calc_irrf(max(BASE_IRRF_13, 0))
+        </field>
+    </record>
+
+    <!-- FGTS sobre 13º (8% do 13º bruto) -->
+    <record id="hr_rule_fgts_13" model="hr.salary.rule">
+        <field name="name">FGTS (13º)</field>
+        <field name="sequence" eval="150" />
+        <field name="code">FGTS</field>
+        <field
+            name="category_id"
+            ref="l10n_br_hr_payroll.hr_salary_rule_category_comp"
+        />
+        <field name="condition_select">python</field>
+        <field name="condition_python">
+result = employee.l10n_br_tipo_contrato != 'aprendiz'
+        </field>
+        <field name="amount_select">code</field>
+        <field name="amount_python_compute">
+result = tools.br.round_money(max(categories.GROSS, 0) * 0.08)
+        </field>
+    </record>
+
+    <!-- Dedução da 1ª parcela (adiantamento) já paga -->
+    <record id="hr_rule_desconto_adiantamento_13" model="hr.salary.rule">
+        <field name="name">Adiantamento 13º (1ª parcela)</field>
+        <field name="sequence" eval="160" />
+        <field name="code">ADIANTAMENTO_13</field>
+        <field
+            name="category_id"
+            ref="l10n_br_hr_payroll.hr_salary_rule_category_ded"
+        />
+        <field name="condition_select">python</field>
+        <field name="condition_python">
+result = payslip.l10n_br_primeira_parcela_13_paga > 0
+        </field>
+        <field name="amount_select">code</field>
+        <field name="amount_python_compute">
+# Deduz o adiantamento (1ª parcela) para não pagar em dobro.
+result = payslip.l10n_br_primeira_parcela_13_paga
         </field>
     </record>
 

--- a/l10n_br_hr_vacation/data/hr_salary_rule_ferias_data.xml
+++ b/l10n_br_hr_vacation/data/hr_salary_rule_ferias_data.xml
@@ -5,9 +5,26 @@
 
         Convenção: mesmos padrões de l10n_br_hr_payroll.
         Variáveis bare code, NÃO usar rules.CÓDIGO.
+
+        Fundamentação:
+          - Férias gozadas + 1/3 constitucional: verbas TRIBUTÁVEIS
+            (INSS, IRRF e FGTS incidem).
+          - Abono pecuniário (venda de até 1/3 das férias, CLT art. 143) e
+            seu 1/3 constitucional: verbas INDENIZATÓRIAS. NÃO incide INSS
+            (Lei 8.212/91 art. 28 §9º "e" 6) nem IRRF (ADI SRF 5/2005),
+            nem FGTS. Ficam na categoria PROV_INDENIZ, fora do GROSS/base
+            tributável, mas somadas ao NET.
+          - Ao vender 10 dias, o empregado GOZA 20 dias: as férias gozadas
+            são proporcionais (20/30) via l10n_br_dias_ferias_gozadas.
     -->
 
-    <!-- Férias (valor base = salário) -->
+    <!-- Categoria de proventos indenizatórios (fora da base tributável) -->
+    <record id="hr_salary_rule_category_prov_indeniz" model="hr.salary.rule.category">
+        <field name="name">Provento Indenizatório</field>
+        <field name="code">PROV_INDENIZ</field>
+    </record>
+
+    <!-- Férias gozadas (proporcional aos dias efetivamente gozados) -->
     <record id="hr_rule_ferias" model="hr.salary.rule">
         <field name="name">Férias</field>
         <field name="sequence" eval="1" />
@@ -19,11 +36,14 @@
         <field name="condition_select">none</field>
         <field name="amount_select">code</field>
         <field name="amount_python_compute">
-result = contract.wage
+# Férias proporcionais aos dias gozados: ao vender o abono (10 dias), o
+# empregado goza 20 dias => 20/30 do salário (CLT art. 143).
+dias_gozados = payslip.l10n_br_dias_ferias_gozadas
+result = tools.br.round_money(contract.wage * dias_gozados / 30)
         </field>
     </record>
 
-    <!-- Adicional de Férias (1/3 constitucional) -->
+    <!-- Adicional de Férias (1/3 constitucional sobre as férias gozadas) -->
     <record id="hr_rule_adicional_ferias" model="hr.salary.rule">
         <field name="name">Adicional de Férias (1/3)</field>
         <field name="sequence" eval="2" />
@@ -39,27 +59,41 @@ result = tools.br.round_money(FERIAS / 3)
         </field>
     </record>
 
-    <!-- Abono Pecuniário (venda de 1/3 das férias) -->
+    <!-- Abono Pecuniário (venda de 1/3 das férias) — INDENIZATÓRIO -->
     <record id="hr_rule_abono_pecuniario" model="hr.salary.rule">
         <field name="name">Abono Pecuniário</field>
         <field name="sequence" eval="3" />
         <field name="code">ABONO_PECUNIARIO</field>
-        <field
-            name="category_id"
-            ref="l10n_br_hr_payroll.hr_salary_rule_category_alw"
-        />
+        <field name="category_id" ref="hr_salary_rule_category_prov_indeniz" />
         <field name="condition_select">python</field>
         <field name="condition_python">
 result = payslip.l10n_br_abono_pecuniario
         </field>
         <field name="amount_select">code</field>
         <field name="amount_python_compute">
-# Abono pecuniário = 10 dias (1/3 de 30) × salário-dia
-result = tools.br.round_money((contract.wage / 30) * 10)
+# Dias vendidos = 30 - dias gozados (10 dias quando vende 1/3).
+dias_vendidos = 30 - payslip.l10n_br_dias_ferias_gozadas
+result = tools.br.round_money((contract.wage / 30) * dias_vendidos)
         </field>
     </record>
 
-    <!-- GROSS para férias -->
+    <!-- 1/3 constitucional sobre o abono pecuniário — INDENIZATÓRIO -->
+    <record id="hr_rule_adicional_abono" model="hr.salary.rule">
+        <field name="name">Adicional sobre Abono (1/3)</field>
+        <field name="sequence" eval="4" />
+        <field name="code">ADICIONAL_ABONO</field>
+        <field name="category_id" ref="hr_salary_rule_category_prov_indeniz" />
+        <field name="condition_select">python</field>
+        <field name="condition_python">
+result = payslip.l10n_br_abono_pecuniario
+        </field>
+        <field name="amount_select">code</field>
+        <field name="amount_python_compute">
+result = tools.br.round_money(ABONO_PECUNIARIO / 3)
+        </field>
+    </record>
+
+    <!-- GROSS para férias (apenas verbas TRIBUTÁVEIS: férias gozadas + 1/3) -->
     <record id="hr_rule_gross_ferias" model="hr.salary.rule">
         <field name="name">Remuneração Bruta (Férias)</field>
         <field name="sequence" eval="99" />
@@ -75,7 +109,7 @@ result = categories.BASIC + categories.ALW
         </field>
     </record>
 
-    <!-- INSS sobre férias -->
+    <!-- INSS sobre férias (só verbas tributáveis) -->
     <record id="hr_rule_inss_ferias" model="hr.salary.rule">
         <field name="name">INSS (Férias)</field>
         <field name="sequence" eval="100" />
@@ -130,7 +164,26 @@ result = tools.br.calc_irrf(max(BASE_IRRF, 0))
         </field>
     </record>
 
-    <!-- NET férias -->
+    <!-- FGTS sobre férias (8% das verbas tributáveis: férias gozadas + 1/3) -->
+    <record id="hr_rule_fgts_ferias" model="hr.salary.rule">
+        <field name="name">FGTS (Férias)</field>
+        <field name="sequence" eval="150" />
+        <field name="code">FGTS</field>
+        <field
+            name="category_id"
+            ref="l10n_br_hr_payroll.hr_salary_rule_category_comp"
+        />
+        <field name="condition_select">python</field>
+        <field name="condition_python">
+result = employee.l10n_br_tipo_contrato != 'aprendiz'
+        </field>
+        <field name="amount_select">code</field>
+        <field name="amount_python_compute">
+result = tools.br.round_money(max(categories.GROSS, 0) * 0.08)
+        </field>
+    </record>
+
+    <!-- NET férias (inclui os proventos indenizatórios; FGTS/COMP não afeta) -->
     <record id="hr_rule_net_ferias" model="hr.salary.rule">
         <field name="name">Líquido (Férias)</field>
         <field name="sequence" eval="200" />
@@ -142,7 +195,9 @@ result = tools.br.calc_irrf(max(BASE_IRRF, 0))
         <field name="condition_select">none</field>
         <field name="amount_select">code</field>
         <field name="amount_python_compute">
-result = categories.BASIC + categories.ALW - categories.DED
+result = (
+    categories.BASIC + categories.ALW + categories.PROV_INDENIZ - categories.DED
+)
         </field>
     </record>
 </odoo>

--- a/l10n_br_hr_vacation/data/hr_salary_rule_rescisao_data.xml
+++ b/l10n_br_hr_vacation/data/hr_salary_rule_rescisao_data.xml
@@ -1,0 +1,252 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <!--
+        Regras salariais da Rescisão (verbas rescisórias SEGURAS).
+
+        ESCOPO IMPLEMENTADO (verbas bem fundamentadas):
+          - Saldo de salário proporcional aos dias trabalhados no mês
+            (CLT art. 457/459). TRIBUTÁVEL: INSS, IRRF e FGTS.
+          - 13º proporcional aos avos até a rescisão (CLT/Lei 4.090/62).
+            TRIBUTÁVEL com incidência SEPARADA de INSS e IRRF (o 13º nunca
+            se soma ao salário do mês para fins de imposto) e FGTS.
+          - Férias proporcionais + 1/3 constitucional. INDENIZATÓRIAS na
+            rescisão: NÃO incidem INSS (Lei 8.212/91 art. 28 §9º), IRRF
+            (Súmula 386 STJ / ADI SRF 5/2005) nem FGTS.
+
+        LACUNAS DELIBERADAS (exigem validação fiscal / dados adicionais —
+        ver relatório): aviso prévio (indenizado/trabalhado) e reflexos;
+        multa de 40% do FGTS; distinção por tipo de rescisão (sem justa
+        causa, pedido, justa causa, comum acordo); férias VENCIDAS de
+        períodos aquisitivos completos não gozados (dependem de rastreio
+        de alocações); médias de horas extras/adicionais habituais.
+
+        Convenção de sinais: proventos positivos; DED positivo subtraído;
+        NET = proventos - descontos. FGTS é COMP (não afeta o NET).
+    -->
+
+    <!-- Saldo de salário proporcional aos dias trabalhados no mês -->
+    <record id="hr_rule_saldo_salario" model="hr.salary.rule">
+        <field name="name">Saldo de Salário</field>
+        <field name="sequence" eval="1" />
+        <field name="code">SALDO_SALARIO</field>
+        <field
+            name="category_id"
+            ref="l10n_br_hr_payroll.hr_salary_rule_category_basic"
+        />
+        <field name="condition_select">none</field>
+        <field name="amount_select">code</field>
+        <field name="amount_python_compute">
+# Dias trabalhados no mês da rescisão (mês comercial de 30 dias).
+# Assume período iniciando no dia 1º; dias = dia do desligamento.
+dias = payslip.date_to.day
+result = tools.br.round_money((contract.wage / 30) * dias)
+        </field>
+    </record>
+
+    <!-- Férias proporcionais (INDENIZATÓRIAS) -->
+    <record id="hr_rule_ferias_indenizadas" model="hr.salary.rule">
+        <field name="name">Férias Proporcionais (Indenizadas)</field>
+        <field name="sequence" eval="6" />
+        <field name="code">FERIAS_INDENIZADAS</field>
+        <field name="category_id" ref="hr_salary_rule_category_prov_indeniz" />
+        <field name="condition_select">python</field>
+        <field name="condition_python">
+result = payslip.l10n_br_avos_ferias > 0
+        </field>
+        <field name="amount_select">code</field>
+        <field name="amount_python_compute">
+avos = payslip.l10n_br_avos_ferias
+result = tools.br.round_money(contract.wage * avos / 12)
+        </field>
+    </record>
+
+    <!-- 1/3 constitucional sobre as férias proporcionais (INDENIZATÓRIO) -->
+    <record id="hr_rule_adicional_ferias_indenizadas" model="hr.salary.rule">
+        <field name="name">Adicional Férias Indenizadas (1/3)</field>
+        <field name="sequence" eval="7" />
+        <field name="code">ADICIONAL_FERIAS_INDENIZADAS</field>
+        <field name="category_id" ref="hr_salary_rule_category_prov_indeniz" />
+        <field name="condition_select">python</field>
+        <field name="condition_python">
+result = payslip.l10n_br_avos_ferias > 0
+        </field>
+        <field name="amount_select">code</field>
+        <field name="amount_python_compute">
+result = tools.br.round_money(FERIAS_INDENIZADAS / 3)
+        </field>
+    </record>
+
+    <!-- INSS sobre o saldo de salário -->
+    <record id="hr_rule_inss_rescisao" model="hr.salary.rule">
+        <field name="name">INSS (Saldo de Salário)</field>
+        <field name="sequence" eval="100" />
+        <field name="code">INSS</field>
+        <field
+            name="category_id"
+            ref="l10n_br_hr_payroll.hr_salary_rule_category_ded"
+        />
+        <field name="condition_select">python</field>
+        <field name="condition_python">
+result = employee.l10n_br_tipo_contrato != 'aprendiz'
+        </field>
+        <field name="amount_select">code</field>
+        <field name="amount_python_compute">
+result = tools.br.calc_inss(max(SALDO_SALARIO, 0))
+        </field>
+    </record>
+
+    <!-- INSS sobre o 13º proporcional (incidência separada) -->
+    <record id="hr_rule_inss_13_rescisao" model="hr.salary.rule">
+        <field name="name">INSS (13º Rescisão)</field>
+        <field name="sequence" eval="101" />
+        <field name="code">INSS_13</field>
+        <field
+            name="category_id"
+            ref="l10n_br_hr_payroll.hr_salary_rule_category_ded"
+        />
+        <field name="condition_select">python</field>
+        <field name="condition_python">
+result = employee.l10n_br_tipo_contrato != 'aprendiz'
+        </field>
+        <field name="amount_select">code</field>
+        <field name="amount_python_compute">
+result = tools.br.calc_inss(max(DECIMO_RESCISAO, 0))
+        </field>
+    </record>
+
+    <!-- Base IRRF do saldo de salário -->
+    <record id="hr_rule_base_irrf_rescisao" model="hr.salary.rule">
+        <field name="name">Base IRRF (Saldo de Salário)</field>
+        <field name="sequence" eval="110" />
+        <field name="code">BASE_IRRF</field>
+        <field
+            name="category_id"
+            ref="l10n_br_hr_payroll.hr_salary_rule_category_info"
+        />
+        <field name="condition_select">none</field>
+        <field name="amount_select">code</field>
+        <field name="amount_python_compute">
+dependentes = employee.l10n_br_irrf_dependentes * tools.br.irrf_deducao_dependente()
+pensao = employee.l10n_br_pensao_alimenticia
+result = SALDO_SALARIO - INSS - dependentes - pensao
+        </field>
+    </record>
+
+    <!-- Base IRRF do 13º proporcional (incidência separada) -->
+    <record id="hr_rule_base_irrf_13_rescisao" model="hr.salary.rule">
+        <field name="name">Base IRRF (13º Rescisão)</field>
+        <field name="sequence" eval="111" />
+        <field name="code">BASE_IRRF_13</field>
+        <field
+            name="category_id"
+            ref="l10n_br_hr_payroll.hr_salary_rule_category_info"
+        />
+        <field name="condition_select">none</field>
+        <field name="amount_select">code</field>
+        <field name="amount_python_compute">
+dependentes = employee.l10n_br_irrf_dependentes * tools.br.irrf_deducao_dependente()
+result = DECIMO_RESCISAO - INSS_13 - dependentes
+        </field>
+    </record>
+
+    <!-- IRRF sobre o saldo de salário -->
+    <record id="hr_rule_irrf_rescisao" model="hr.salary.rule">
+        <field name="name">IRRF (Saldo de Salário)</field>
+        <field name="sequence" eval="120" />
+        <field name="code">IRRF</field>
+        <field
+            name="category_id"
+            ref="l10n_br_hr_payroll.hr_salary_rule_category_ded"
+        />
+        <field name="condition_select">python</field>
+        <field name="condition_python">
+result = not employee.l10n_br_molestia_grave
+        </field>
+        <field name="amount_select">code</field>
+        <field name="amount_python_compute">
+result = tools.br.calc_irrf(max(BASE_IRRF, 0))
+        </field>
+    </record>
+
+    <!-- IRRF sobre o 13º proporcional (incidência separada) -->
+    <record id="hr_rule_irrf_13_rescisao" model="hr.salary.rule">
+        <field name="name">IRRF (13º Rescisão)</field>
+        <field name="sequence" eval="121" />
+        <field name="code">IRRF_13</field>
+        <field
+            name="category_id"
+            ref="l10n_br_hr_payroll.hr_salary_rule_category_ded"
+        />
+        <field name="condition_select">python</field>
+        <field name="condition_python">
+result = not employee.l10n_br_molestia_grave
+        </field>
+        <field name="amount_select">code</field>
+        <field name="amount_python_compute">
+result = tools.br.calc_irrf(max(BASE_IRRF_13, 0))
+        </field>
+    </record>
+
+    <!-- FGTS sobre o saldo de salário -->
+    <record id="hr_rule_fgts_rescisao" model="hr.salary.rule">
+        <field name="name">FGTS (Saldo de Salário)</field>
+        <field name="sequence" eval="150" />
+        <field name="code">FGTS</field>
+        <field
+            name="category_id"
+            ref="l10n_br_hr_payroll.hr_salary_rule_category_comp"
+        />
+        <field name="condition_select">python</field>
+        <field name="condition_python">
+result = employee.l10n_br_tipo_contrato != 'aprendiz'
+        </field>
+        <field name="amount_select">code</field>
+        <field name="amount_python_compute">
+result = tools.br.round_money(max(SALDO_SALARIO, 0) * 0.08)
+        </field>
+    </record>
+
+    <!-- FGTS sobre o 13º proporcional -->
+    <record id="hr_rule_fgts_13_rescisao" model="hr.salary.rule">
+        <field name="name">FGTS (13º Rescisão)</field>
+        <field name="sequence" eval="151" />
+        <field name="code">FGTS_13</field>
+        <field
+            name="category_id"
+            ref="l10n_br_hr_payroll.hr_salary_rule_category_comp"
+        />
+        <field name="condition_select">python</field>
+        <field name="condition_python">
+result = employee.l10n_br_tipo_contrato != 'aprendiz'
+        </field>
+        <field name="amount_select">code</field>
+        <field name="amount_python_compute">
+result = tools.br.round_money(max(DECIMO_RESCISAO, 0) * 0.08)
+        </field>
+    </record>
+
+    <!-- NET rescisão (proventos tributáveis + indenizatórios - descontos) -->
+    <record id="hr_rule_net_rescisao" model="hr.salary.rule">
+        <field name="name">Líquido (Rescisão)</field>
+        <field name="sequence" eval="200" />
+        <field name="code">NET</field>
+        <field
+            name="category_id"
+            ref="l10n_br_hr_payroll.hr_salary_rule_category_net"
+        />
+        <field name="condition_select">none</field>
+        <field name="amount_select">code</field>
+        <field name="amount_python_compute">
+result = (
+    SALDO_SALARIO
+    + DECIMO_RESCISAO
+    + FERIAS_INDENIZADAS
+    + ADICIONAL_FERIAS_INDENIZADAS
+    - INSS
+    - INSS_13
+    - IRRF
+    - IRRF_13
+)
+        </field>
+    </record>
+</odoo>

--- a/l10n_br_hr_vacation/models/hr_payslip.py
+++ b/l10n_br_hr_vacation/models/hr_payslip.py
@@ -1,6 +1,8 @@
 # Copyright 2024 KMEE
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from dateutil.relativedelta import relativedelta
+
 from odoo import api, fields, models
 
 
@@ -18,6 +20,12 @@ class HrPayslip(models.Model):
     l10n_br_avos_13 = fields.Integer(
         string="Avos de 13º",
         compute="_compute_avos_13",
+    )
+    l10n_br_avos_ferias = fields.Integer(
+        string="Avos de Férias Proporcionais",
+        compute="_compute_avos_ferias",
+        help="Meses (fração >= 15 dias) do período aquisitivo em curso, "
+        "usados para as férias proporcionais na rescisão.",
     )
     l10n_br_primeira_parcela_13_paga = fields.Float(
         string="1ª Parcela do 13º já paga",
@@ -50,6 +58,45 @@ class HrPayslip(models.Model):
             else:
                 rec.l10n_br_avos_13 = 0
 
+    @api.depends("contract_id", "date_to")
+    def _compute_avos_ferias(self):
+        for rec in self:
+            if rec.contract_id and rec.contract_id.date_start and rec.date_to:
+                rec.l10n_br_avos_ferias = self._calc_avos_ferias_proporcionais(
+                    rec.contract_id.date_start, rec.date_to
+                )
+            else:
+                rec.l10n_br_avos_ferias = 0
+
+    @staticmethod
+    def _calc_avos_ferias_proporcionais(data_admissao, data_referencia):
+        """Avos de férias proporcionais do período aquisitivo em curso.
+
+        Conta os meses (alinhados ao aniversário de admissão) com fração
+        igual ou superior a 15 dias, desde o início do período aquisitivo
+        em curso (último aniversário de admissão <= referência) até a data
+        de referência (rescisão). Máximo de 12 avos.
+
+        Nota: NÃO considera férias vencidas de períodos aquisitivos
+        completos e não gozados — ver relatório (lacuna).
+        """
+        anos = data_referencia.year - data_admissao.year
+        inicio = data_admissao + relativedelta(years=anos)
+        if inicio > data_referencia:
+            inicio = data_admissao + relativedelta(years=anos - 1)
+        avos = 0
+        cursor = inicio
+        while cursor <= data_referencia:
+            fim_mes = cursor + relativedelta(months=1) - relativedelta(days=1)
+            if fim_mes <= data_referencia:
+                avos += 1
+            else:
+                dias = (data_referencia - cursor).days + 1
+                if dias >= 15:
+                    avos += 1
+            cursor += relativedelta(months=1)
+        return min(avos, 12)
+
     @api.depends("line_ids", "l10n_br_primeira_parcela_13_paga")
     def _compute_liquido_13(self):
         for rec in self:
@@ -78,11 +125,16 @@ class HrPayslip(models.Model):
             "FERIAS",
             "ADICIONAL_FERIAS",
             "ABONO_PECUNIARIO",
+            "ADICIONAL_ABONO",
             "DECIMO_TERCEIRO_BRUTO",
             "ADIANTAMENTO_13",
             "INSS_13",
             "IRRF_13",
+            "BASE_IRRF_13",
             "DECIMO_RESCISAO",
+            "SALDO_SALARIO",
+            "FERIAS_INDENIZADAS",
+            "ADICIONAL_FERIAS_INDENIZADAS",
         ):
             localdict.setdefault(code, 0.0)
         return localdict

--- a/l10n_br_hr_vacation/tests/__init__.py
+++ b/l10n_br_hr_vacation/tests/__init__.py
@@ -4,3 +4,4 @@
 from . import test_ferias
 from . import test_decimo_terceiro
 from . import test_ciclo_anual
+from . import test_rescisao

--- a/l10n_br_hr_vacation/tests/test_decimo_terceiro.py
+++ b/l10n_br_hr_vacation/tests/test_decimo_terceiro.py
@@ -11,9 +11,12 @@ Cobertura:
 """
 from datetime import date
 
+from odoo.tests import tagged
+
 from .common import VacationCommon
 
 
+@tagged("post_install", "-at_install")
 class TestDecimoTerceiro(VacationCommon):
     """Testes do 13º Salário."""
 
@@ -102,11 +105,59 @@ class TestDecimoTerceiro(VacationCommon):
         payslip.compute_sheet()
         inss_13 = self._get_line_total(payslip, "INSS_13")
         irrf_13 = self._get_line_total(payslip, "IRRF_13")
+        # A dedução da 1ª parcela deve existir como linha DED (ADIANTAMENTO_13),
+        # não apenas no campo computado — senão paga-se o 13º em dobro.
+        adiantamento_ded = self._get_line_total(payslip, "ADIANTAMENTO_13")
+        net = self._get_line_total(payslip, "NET")
         liquido = payslip.l10n_br_liquido_13
         expected_liquido = 5000.00 - inss_13 - irrf_13 - 2500.00
+        self.assertAlmostEqualMoney(adiantamento_ded, 2500.00)
+        # O NET (linha da folha) já desconta o adiantamento.
+        self.assertAlmostEqualMoney(net, expected_liquido)
         self.assertAlmostEqualMoney(liquido, expected_liquido)
         self.assertGreater(inss_13, 0.0)
         self.assertGreater(irrf_13, 0.0)
+
+    def test_primeira_parcela_proporcional_meio_ano(self):
+        """Admitido no meio do ano: 1ª parcela = metade dos avos projetados."""
+        emp = self._create_employee()
+        contract = self._create_contract(emp, wage=5000.00, date_start=date(2024, 7, 1))
+        payslip = self.env["hr.payslip"].create(
+            {
+                "name": "13º Adiantamento - meio de ano",
+                "employee_id": emp.id,
+                "contract_id": contract.id,
+                "date_from": date(2024, 11, 1),
+                "date_to": date(2024, 11, 30),
+                "struct_id": self.structure_13_primeira.id,
+                "company_id": self.env.company.id,
+            }
+        )
+        payslip.compute_sheet()
+        adiant = self._get_line_total(payslip, "ADIANTAMENTO_13")
+        # Admitido jul: 6 avos até 31/12 => 5000 × 6/12 × 0,5 = 1250
+        self.assertAlmostEqualMoney(adiant, 1250.00)
+
+    def test_fgts_incide_sobre_13(self):
+        """FGTS (8%) incide sobre o 13º bruto na 2ª parcela."""
+        emp = self._create_employee()
+        contract = self._create_contract(emp, wage=5000.00, date_start=date(2024, 1, 1))
+        payslip = self.env["hr.payslip"].create(
+            {
+                "name": "13º 2ª Parcela FGTS",
+                "employee_id": emp.id,
+                "contract_id": contract.id,
+                "date_from": date(2024, 12, 1),
+                "date_to": date(2024, 12, 31),
+                "struct_id": self.structure_13_segunda.id,
+                "company_id": self.env.company.id,
+            }
+        )
+        payslip.compute_sheet()
+        bruto = self._get_line_total(payslip, "DECIMO_TERCEIRO_BRUTO")
+        fgts = self._get_line_total(payslip, "FGTS")
+        self.assertAlmostEqualMoney(bruto, 5000.00)
+        self.assertAlmostEqualMoney(fgts, 400.00)  # 8% de 5000
 
     def test_decimo_na_rescisao_proporcional(self):
         """13º na rescisão = proporcional aos meses trabalhados no ano."""

--- a/l10n_br_hr_vacation/tests/test_ferias.py
+++ b/l10n_br_hr_vacation/tests/test_ferias.py
@@ -10,9 +10,12 @@ Cobertura:
 """
 from datetime import date
 
+from odoo.tests import tagged
+
 from .common import VacationCommon
 
 
+@tagged("post_install", "-at_install")
 class TestDiasFeriasParFaltas(VacationCommon):
     """Tabela CLT art. 130 — Dias de férias por faltas no período aquisitivo."""
 
@@ -87,6 +90,7 @@ class TestDiasFeriasParFaltas(VacationCommon):
         self.assertEqual(alloc.number_of_days, 12)
 
 
+@tagged("post_install", "-at_install")
 class TestValorFerias(VacationCommon):
     """Testes do cálculo do valor monetário das férias."""
 
@@ -131,25 +135,84 @@ class TestValorFerias(VacationCommon):
         adicional = self._get_line_total(payslip, "ADICIONAL_FERIAS")
         self.assertAlmostEqualMoney(adicional, ferias / 3)
 
-    def test_abono_pecuniario_10_dias(self):
-        """Abono pecuniário: venda de 10 dias (1/3 de 30)."""
-        emp = self._create_employee()
-        contract = self._create_contract(emp, wage=6000.00)
-        payslip = self.env["hr.payslip"].create(
+    def _payslip_ferias(self, emp, contract, abono=False, wage_month=(2024, 5)):
+        year, month = wage_month
+        return self.env["hr.payslip"].create(
             {
-                "name": "Férias com Abono - Teste",
+                "name": "Férias - Teste",
                 "employee_id": emp.id,
                 "contract_id": contract.id,
-                "date_from": date(2024, 5, 1),
-                "date_to": date(2024, 5, 30),
+                "date_from": date(year, month, 1),
+                "date_to": date(year, month, 30),
                 "struct_id": self.structure_ferias.id,
-                "l10n_br_abono_pecuniario": True,
+                "l10n_br_abono_pecuniario": abono,
                 "company_id": self.env.company.id,
             }
         )
+
+    def test_abono_pecuniario_ferias_proporcionais(self):
+        """Abono: goza 20 dias (férias 20/30), vende 10 dias + 1/3 sobre cada.
+
+        CLT art. 143: ao vender 1/3 (10 dias), o empregado GOZA 20 dias.
+        Férias = 20/30 do salário; abono = 10/30 do salário; cada verba
+        recebe o seu 1/3 constitucional.
+        """
+        emp = self._create_employee()
+        contract = self._create_contract(emp, wage=6000.00)
+        payslip = self._payslip_ferias(emp, contract, abono=True)
         payslip.compute_sheet()
-        ferias_gozadas = payslip.l10n_br_dias_ferias_gozadas
+
+        ferias = self._get_line_total(payslip, "FERIAS")
+        adicional = self._get_line_total(payslip, "ADICIONAL_FERIAS")
         abono = self._get_line_total(payslip, "ABONO_PECUNIARIO")
-        self.assertEqual(ferias_gozadas, 20)
-        # Abono: 10 dias × (6000/30) = 2000
+        adicional_abono = self._get_line_total(payslip, "ADICIONAL_ABONO")
+
+        self.assertEqual(payslip.l10n_br_dias_ferias_gozadas, 20)
+        # Férias gozadas proporcionais: 20/30 × 6000 = 4000 (NÃO paga 30 dias)
+        self.assertAlmostEqualMoney(ferias, 4000.00)
+        self.assertAlmostEqualMoney(adicional, 4000.00 / 3)
+        # Abono: 10 dias × (6000/30) = 2000, com 1/3 constitucional próprio
         self.assertAlmostEqualMoney(abono, 2000.00)
+        self.assertAlmostEqualMoney(adicional_abono, 2000.00 / 3)
+
+    def test_abono_isento_inss_irrf(self):
+        """Abono e seu 1/3 são indenizatórios: fora do GROSS/base tributável."""
+        emp = self._create_employee()
+        contract = self._create_contract(emp, wage=6000.00)
+        com_abono = self._payslip_ferias(emp, contract, abono=True)
+        com_abono.compute_sheet()
+
+        ferias = self._get_line_total(com_abono, "FERIAS")
+        adicional = self._get_line_total(com_abono, "ADICIONAL_FERIAS")
+        gross = self._get_line_total(com_abono, "GROSS")
+        base_irrf = self._get_line_total(com_abono, "BASE_IRRF")
+        inss = self._get_line_total(com_abono, "INSS")
+
+        # GROSS = apenas férias gozadas + 1/3 (abono + 1/3 excluídos).
+        # Como INSS/IRRF incidem sobre o GROSS, isto prova a isenção do abono.
+        self.assertAlmostEqualMoney(gross, ferias + adicional)
+        # A base tributável não pode conter o abono (2000) nem seu 1/3.
+        self.assertLess(base_irrf, gross)
+        self.assertGreater(inss, 0.0)
+
+    def test_fgts_ferias(self):
+        """FGTS incide sobre férias gozadas + 1/3 (8%)."""
+        emp = self._create_employee()
+        contract = self._create_contract(emp, wage=6000.00)
+        payslip = self._payslip_ferias(emp, contract, abono=False)
+        payslip.compute_sheet()
+        gross = self._get_line_total(payslip, "GROSS")
+        fgts = self._get_line_total(payslip, "FGTS")
+        self.assertAlmostEqualMoney(gross, 8000.00)  # 6000 + 1/3
+        self.assertAlmostEqualMoney(fgts, 640.00)  # 8% de 8000
+
+    def test_fgts_ferias_exclui_abono(self):
+        """FGTS não incide sobre o abono (indenizatório)."""
+        emp = self._create_employee()
+        contract = self._create_contract(emp, wage=6000.00)
+        payslip = self._payslip_ferias(emp, contract, abono=True)
+        payslip.compute_sheet()
+        gross = self._get_line_total(payslip, "GROSS")
+        fgts = self._get_line_total(payslip, "FGTS")
+        # FGTS = 8% do GROSS (férias gozadas + 1/3), sem o abono.
+        self.assertAlmostEqualMoney(fgts, round(gross * 0.08, 2))

--- a/l10n_br_hr_vacation/tests/test_rescisao.py
+++ b/l10n_br_hr_vacation/tests/test_rescisao.py
@@ -1,0 +1,123 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+"""
+Testes ORM: Rescisão (verbas rescisórias seguras).
+
+Cobertura:
+  - Saldo de salário proporcional aos dias trabalhados
+  - 13º proporcional (incidência de INSS/IRRF/FGTS separada)
+  - Férias proporcionais + 1/3 (indenizatórias: isentas de INSS/IRRF/FGTS)
+  - Composição do NET
+"""
+from datetime import date
+
+from odoo.tests import tagged
+
+from .common import VacationCommon
+
+
+@tagged("post_install", "-at_install")
+class TestRescisao(VacationCommon):
+    """Testes das verbas rescisórias implementadas."""
+
+    def _rescisao(self, wage=3000.00, date_start=None, date_from=None, date_to=None):
+        emp = self._create_employee("Rescisão")
+        contract = self._create_contract(
+            emp, wage=wage, date_start=date_start or date(2024, 1, 1)
+        )
+        rescisao = self.env["hr.payslip"].create(
+            {
+                "name": "Rescisão",
+                "employee_id": emp.id,
+                "contract_id": contract.id,
+                "date_from": date_from or date(2024, 9, 1),
+                "date_to": date_to or date(2024, 9, 30),
+                "struct_id": self.structure_rescisao.id,
+                "company_id": self.env.company.id,
+            }
+        )
+        rescisao.compute_sheet()
+        return rescisao
+
+    def test_saldo_salario_mes_cheio(self):
+        """Rescisão no dia 30: saldo de salário = salário integral."""
+        rescisao = self._rescisao(wage=3000.00)
+        self.assertAlmostEqualMoney(
+            self._get_line_total(rescisao, "SALDO_SALARIO"), 3000.00
+        )
+
+    def test_saldo_salario_proporcional_dias(self):
+        """Rescisão no dia 15: saldo = 15/30 do salário."""
+        rescisao = self._rescisao(
+            wage=3000.00, date_from=date(2024, 9, 1), date_to=date(2024, 9, 15)
+        )
+        self.assertAlmostEqualMoney(
+            self._get_line_total(rescisao, "SALDO_SALARIO"), 1500.00
+        )
+
+    def test_decimo_proporcional_avos(self):
+        """13º proporcional aos avos até a rescisão (9/12)."""
+        rescisao = self._rescisao(wage=3000.00)
+        self.assertAlmostEqualMoney(
+            self._get_line_total(rescisao, "DECIMO_RESCISAO"), 2250.00
+        )
+
+    def test_ferias_proporcionais_com_terco(self):
+        """Férias proporcionais (9/12) + 1/3 constitucional."""
+        rescisao = self._rescisao(wage=3000.00)
+        ferias = self._get_line_total(rescisao, "FERIAS_INDENIZADAS")
+        adicional = self._get_line_total(rescisao, "ADICIONAL_FERIAS_INDENIZADAS")
+        self.assertEqual(rescisao.l10n_br_avos_ferias, 9)
+        self.assertAlmostEqualMoney(ferias, 2250.00)  # 9/12 × 3000
+        self.assertAlmostEqualMoney(adicional, 750.00)  # 1/3 de 2250
+
+    def test_ferias_indenizadas_isentas(self):
+        """Férias indenizadas + 1/3 não sofrem INSS, IRRF nem FGTS.
+
+        Prova indireta: o INSS incide só sobre o saldo de salário e o
+        INSS_13 só sobre o 13º; o FGTS idem. Se as férias indenizadas
+        entrassem em alguma base, os valores mudariam.
+        """
+        rescisao = self._rescisao(wage=3000.00)
+        saldo = self._get_line_total(rescisao, "SALDO_SALARIO")
+        inss = self._get_line_total(rescisao, "INSS")
+        inss_13 = self._get_line_total(rescisao, "INSS_13")
+        decimo = self._get_line_total(rescisao, "DECIMO_RESCISAO")
+        # INSS do saldo bate com INSS sobre o próprio saldo (não sobre saldo+férias)
+        base_inss = self._get_line_total(rescisao, "BASE_IRRF") + inss
+        # BASE_IRRF = saldo - inss - deps - pensao; sem dependentes/pensão => saldo-inss
+        self.assertAlmostEqualMoney(base_inss, saldo)
+        self.assertGreater(inss, 0.0)
+        self.assertGreater(inss_13, 0.0)
+        # FGTS só sobre saldo e 13º:
+        fgts = self._get_line_total(rescisao, "FGTS")
+        fgts_13 = self._get_line_total(rescisao, "FGTS_13")
+        self.assertAlmostEqualMoney(fgts, round(saldo * 0.08, 2))
+        self.assertAlmostEqualMoney(fgts_13, round(decimo * 0.08, 2))
+
+    def test_net_composicao(self):
+        """NET = saldo + 13º + férias + 1/3 - INSS - INSS_13 - IRRF - IRRF_13."""
+        rescisao = self._rescisao(wage=3000.00)
+        g = lambda c: self._get_line_total(rescisao, c)  # noqa: E731
+        esperado = (
+            g("SALDO_SALARIO")
+            + g("DECIMO_RESCISAO")
+            + g("FERIAS_INDENIZADAS")
+            + g("ADICIONAL_FERIAS_INDENIZADAS")
+            - g("INSS")
+            - g("INSS_13")
+            - g("IRRF")
+            - g("IRRF_13")
+        )
+        self.assertAlmostEqualMoney(g("NET"), esperado)
+        self.assertGreater(g("NET"), 0.0)
+
+    def test_avos_ferias_periodo_aquisitivo_em_curso(self):
+        """Avos de férias contam apenas o período aquisitivo em curso."""
+        Payslip = self.env["hr.payslip"]
+        # Admitido há mais de 1 ano: período em curso reinicia no aniversário.
+        avos = Payslip._calc_avos_ferias_proporcionais(
+            date(2022, 3, 15), date(2024, 9, 30)
+        )
+        # Período em curso: 15/03/2024 -> 30/09/2024 = ~6,5 meses => 7 avos
+        self.assertEqual(avos, 7)


### PR DESCRIPTION
Onda 3 do backlog da folha (PRD). **Encadeado na #407** (usa as tabelas por competência) — revisar/mergear após a #407.

## RF-04 — Abono pecuniário (P0)
- Férias proporcionais aos dias gozados (20/30 ao vender 10 dias) — antes pagava 40 dias. **CLT art. 143**.
- Adiciona 1/3 constitucional sobre o abono.
- Abono + 1/3 movidos para categoria indenizatória `PROV_INDENIZ`, **fora do GROSS/base de INSS/IRRF/FGTS** (Lei 8.212/91 art. 28 §9º; ADI SRF 5/2005).

## RF-05 — 13º (P0 + P1)
- Dedução do adiantamento vira regra **DED `ADIANTAMENTO_13`** na 2ª parcela, refletindo na linha **NET** (antes só no campo computado → risco de pagar em dobro).
- 1ª parcela proporcional aos avos (era 50% fixo).

## RF-06 — Rescisão (P0)
Substitui a estrutura inútil (salário cheio sem descontos) por verbas seguras: saldo de salário proporcional, 13º proporcional (INSS/IRRF/FGTS separados), férias proporcionais + 1/3 indenizadas (isentas), com NET explícito.

**⚠ Lacunas documentadas no cabeçalho do arquivo — exigem validação fiscal antes de usar rescisão em produção:** aviso prévio, multa 40% FGTS, distinção por tipo de rescisão, férias vencidas, avos do 13º em rescisão de meio de mês.

## P1
- FGTS incidindo sobre férias gozadas+1/3 e sobre 13º.

## Validação
CI do repo quebrado por infra — validado **localmente**: 192 testes (payroll + vacation + payroll_account + benefit), **0 falha/0 erro**. Inclui a reescrita dos testes que consagravam o bug do abono + `test_rescisao` novo.

## Nota operacional
As `hr.salary.rule` são `noupdate="1"` — mudanças de regra **só entram com reinstalação** do módulo (`-i` em base nova), não com `-u`. Relevante para o rollout em bases existentes.

## Pendências fiscais (@mileo)
Ver as 7 lacunas de rescisão documentadas; decidir se médias de HE/adicionais (Súmula 45 TST) entram agora ou viram tarefa própria (dependem de histórico de holerites); confirmar dedução de dependente nas duas bases.