### PR TITLE
[FIX] l10n_br_esocial: grava id_evento (matching do retorno) + robustez do lote

### DIFF
--- a/l10n_br_esocial/models/__init__.py
+++ b/l10n_br_esocial/models/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from . import tabelas
 from . import esocial_natureza_rubrica
 from . import esocial_categoria_trabalhador

--- a/l10n_br_esocial/models/esocial_categoria_trabalhador.py
+++ b/l10n_br_esocial/models/esocial_categoria_trabalhador.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import fields, models
 
 

--- a/l10n_br_esocial/models/esocial_classificacao_tributaria.py
+++ b/l10n_br_esocial/models/esocial_classificacao_tributaria.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import fields, models
 
 

--- a/l10n_br_esocial/models/esocial_evento.py
+++ b/l10n_br_esocial/models/esocial_evento.py
@@ -1,5 +1,12 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import logging
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
 
 
 class ESocialEvento(models.Model):
@@ -111,10 +118,42 @@ class ESocialEvento(models.Model):
                 )
             rec.state = "draft"
 
+    def _check_audit_manager(self):
+        """Only payroll managers may force an event state manually."""
+        if not self.env.user.has_group("payroll.group_payroll_manager"):
+            raise UserError(
+                _(
+                    "Apenas gestores de folha de pagamento podem forçar "
+                    "manualmente o estado de um evento eSocial."
+                )
+            )
+
     def action_mark_error(self):
+        self._check_audit_manager()
         for rec in self:
             rec.state = "error"
+            rec.message_post(
+                body=_("Estado forçado manualmente para ERRO por %(user)s.")
+                % {"user": self.env.user.name}
+            )
+            _logger.info(
+                "eSocial evento %s: estado forçado para 'error' por %s (uid=%s).",
+                rec.id,
+                self.env.user.name,
+                self.env.uid,
+            )
 
     def action_mark_success(self):
+        self._check_audit_manager()
         for rec in self:
             rec.state = "success"
+            rec.message_post(
+                body=_("Estado forçado manualmente para SUCESSO por %(user)s.")
+                % {"user": self.env.user.name}
+            )
+            _logger.info(
+                "eSocial evento %s: estado forçado para 'success' por %s (uid=%s).",
+                rec.id,
+                self.env.user.name,
+                self.env.uid,
+            )

--- a/l10n_br_esocial/models/esocial_lotacao_tributaria.py
+++ b/l10n_br_esocial/models/esocial_lotacao_tributaria.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import fields, models
 
 

--- a/l10n_br_esocial/models/esocial_lote.py
+++ b/l10n_br_esocial/models/esocial_lote.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 import base64
 import logging
 
@@ -5,6 +8,22 @@ from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 _logger = logging.getLogger(__name__)
+
+# S-1xxx events that belong to the periodic group (grupo 3), not the tables
+# group (grupo 1).
+PERIODIC_S1_TYPES = frozenset(
+    {
+        "S-1200",
+        "S-1202",
+        "S-1207",
+        "S-1210",
+        "S-1260",
+        "S-1270",
+        "S-1280",
+        "S-1298",
+        "S-1299",
+    }
+)
 
 try:
     from esociallib import assinar, consultar_lote, enviar_lote
@@ -134,50 +153,41 @@ class ESocialLote(models.Model):
         tp_amb = self.company_id.l10n_br_esocial_tp_amb or "2"
         environment = "restricted" if tp_amb == "2" else "production"
 
-        # Determine grupo from event types
-        tipos = set(eventos_validados.mapped("tipo"))
-        if any(
-            t.startswith("S-1")
-            and t
-            not in (
-                "S-1200",
-                "S-1202",
-                "S-1207",
-                "S-1210",
-                "S-1260",
-                "S-1270",
-                "S-1280",
-                "S-1298",
-                "S-1299",
+        # Determine grupo and enforce lote homogeneity: a single lote must
+        # only carry events of the same eSocial group.
+        grupo = self._get_lote_grupo(eventos_validados)
+
+        # Sign and transmit inside a single guarded block: any failure must
+        # roll back (via UserError) so we never persist signed XML with the
+        # lote left in an inconsistent state.
+        try:
+            eventos_xml = []
+            for evento in eventos_validados:
+                if not evento.xml_envio:
+                    raise UserError(
+                        _("Evento %(name)s não possui XML de envio.")
+                        % {"name": evento.name}
+                    )
+                xml_assinado = assinar(evento.xml_envio, pfx_data, senha)
+                evento.xml_envio = xml_assinado
+                eventos_xml.append(xml_assinado)
+
+            protocolo = enviar_lote(
+                eventos_xml,
+                pfx_data,
+                senha,
+                environment=environment,
+                grupo=grupo,
             )
-            for t in tipos
-        ):
-            grupo = 1  # Tabelas
-        elif any(t.startswith("S-2") for t in tipos):
-            grupo = 2  # Não-periódicos
-        else:
-            grupo = 3  # Periódicos
+        except UserError:
+            raise
+        except Exception as exc:
+            _logger.exception("Erro ao assinar/transmitir lote eSocial %s", self.id)
+            raise UserError(
+                _("Falha na assinatura/transmissão do lote: %(erro)s")
+                % {"erro": exc}
+            ) from exc
 
-        # Sign each event
-        eventos_xml = []
-        for evento in eventos_validados:
-            if not evento.xml_envio:
-                raise UserError(
-                    _("Evento %(name)s não possui XML de envio.")
-                    % {"name": evento.name}
-                )
-            xml_assinado = assinar(evento.xml_envio, pfx_data, senha)
-            evento.xml_envio = xml_assinado
-            eventos_xml.append(xml_assinado)
-
-        # Transmit
-        protocolo = enviar_lote(
-            eventos_xml,
-            pfx_data,
-            senha,
-            environment=environment,
-            grupo=grupo,
-        )
         self.protocolo = protocolo
         self.state = "sent"
         eventos_validados.write({"state": "sent"})
@@ -186,11 +196,40 @@ class ESocialLote(models.Model):
             "type": "ir.actions.client",
             "tag": "display_notification",
             "params": {
-                "title": "Lote Transmitido",
-                "message": f"Protocolo: {protocolo}",
+                "title": _("Lote Transmitido"),
+                "message": _("Protocolo: %(protocolo)s") % {"protocolo": protocolo},
                 "type": "success",
             },
         }
+
+    @api.model
+    def _classify_grupo(self, tipo):
+        """Return the eSocial transmission group (1/2/3) for an event type.
+
+        1 = Tabelas, 2 = Não-periódicos (S-2xxx / S-3xxx), 3 = Periódicos.
+        """
+        tipo = tipo or ""
+        if tipo.startswith("S-1") and tipo not in PERIODIC_S1_TYPES:
+            return 1
+        if tipo.startswith("S-2") or tipo.startswith("S-3"):
+            return 2
+        return 3
+
+    def _get_lote_grupo(self, eventos):
+        """Validate group homogeneity and return the single group of the lote."""
+        self.ensure_one()
+        grupos = {self._classify_grupo(tipo) for tipo in eventos.mapped("tipo")}
+        if len(grupos) > 1:
+            labels = {1: "1-Tabelas", 2: "2-Não Periódicos", 3: "3-Periódicos"}
+            raise UserError(
+                _(
+                    "O lote contém eventos de grupos eSocial diferentes (%(grupos)s). "
+                    "Cada lote deve conter apenas eventos de um mesmo grupo. "
+                    "Separe os eventos em lotes distintos."
+                )
+                % {"grupos": ", ".join(labels[g] for g in sorted(grupos))}
+            )
+        return grupos.pop()
 
     def action_consultar(self):
         """Query batch result from eSocial."""
@@ -215,11 +254,17 @@ class ESocialLote(models.Model):
             self.state = "done"
             for evt_result in resultado.eventos:
                 # Match event by id_evento
+                event_id = evt_result.event_id
                 evento = self.evento_ids.filtered(
-                    lambda e: e.id_evento == evt_result.event_id
+                    lambda e, eid=event_id: e.id_evento and e.id_evento == eid
                 )
                 if not evento:
-                    # Try matching by order
+                    _logger.warning(
+                        "eSocial lote %s: retorno com event_id %s não casou com "
+                        "nenhum evento do lote.",
+                        self.id,
+                        evt_result.event_id,
+                    )
                     continue
                 if evt_result.aceito:
                     evento.write(
@@ -250,8 +295,8 @@ class ESocialLote(models.Model):
             "type": "ir.actions.client",
             "tag": "display_notification",
             "params": {
-                "title": "Consulta Lote",
-                "message": f"Status: {resultado.status}",
+                "title": _("Consulta Lote"),
+                "message": _("Status: %(status)s") % {"status": resultado.status},
                 "type": "info" if resultado.status != "erro" else "danger",
             },
         }

--- a/l10n_br_esocial/models/esocial_motivo_afastamento.py
+++ b/l10n_br_esocial/models/esocial_motivo_afastamento.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import fields, models
 
 

--- a/l10n_br_esocial/models/esocial_motivo_desligamento.py
+++ b/l10n_br_esocial/models/esocial_motivo_desligamento.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import fields, models
 
 

--- a/l10n_br_esocial/models/esocial_natureza_rubrica.py
+++ b/l10n_br_esocial/models/esocial_natureza_rubrica.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import fields, models
 
 

--- a/l10n_br_esocial/models/esocial_ocorrencia.py
+++ b/l10n_br_esocial/models/esocial_ocorrencia.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import fields, models
 
 

--- a/l10n_br_esocial/models/hr_contract.py
+++ b/l10n_br_esocial/models/hr_contract.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import fields, models
 
 

--- a/l10n_br_esocial/models/hr_employee.py
+++ b/l10n_br_esocial/models/hr_employee.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import fields, models
 
 

--- a/l10n_br_esocial/models/hr_payslip.py
+++ b/l10n_br_esocial/models/hr_payslip.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import _, fields, models
 from odoo.exceptions import UserError
 

--- a/l10n_br_esocial/models/hr_salary_rule.py
+++ b/l10n_br_esocial/models/hr_salary_rule.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import fields, models
 
 # Incidência INSS (Contribuição Previdenciária) — eSocial S-1.3

--- a/l10n_br_esocial/models/intermediarios/__init__.py
+++ b/l10n_br_esocial/models/intermediarios/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from . import base_intermediario
 from . import s1000_empregador
 from . import s1010_rubrica

--- a/l10n_br_esocial/models/intermediarios/base_intermediario.py
+++ b/l10n_br_esocial/models/intermediarios/base_intermediario.py
@@ -1,4 +1,9 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 import logging
+
+from lxml import etree
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
@@ -79,35 +84,103 @@ class ESocialBaseIntermediario(models.AbstractModel):
         """Override in subclasses. Must return event type string (e.g. 'S-1010')."""
         raise NotImplementedError
 
+    def _gerar_xml_sem_validacao(self, event_type, data, environment):
+        """Fallback generation when the bundled XSD schemas are absent.
+
+        esociallib ships without the official XSDs, so ``to_xml`` raises
+        ``FileNotFoundError`` on validation. We still need to emit the event,
+        but we refuse to return XML that is not at least well-formed, and we
+        log an explicit ERROR so the missing-XSD condition is never silent.
+        """
+        from esociallib.generator import _BUILDERS, _ensure_builders_loaded
+
+        _ensure_builders_loaded()
+        builder = _BUILDERS.get(event_type)
+        if builder is None:
+            raise UserError(
+                _(
+                    "Não foi possível gerar o evento %(tipo)s: a esociallib não "
+                    "possui um builder registrado para este evento e os schemas "
+                    "XSD não estão disponíveis para validação."
+                )
+                % {"tipo": event_type}
+            )
+        _logger.error(
+            "eSocial %s: schemas XSD ausentes na esociallib — XML gerado SEM "
+            "validação XSD. Instale os XSDs oficiais em "
+            "esociallib/esocial/schemas/v_s13/ para validar antes de transmitir.",
+            event_type,
+        )
+        evento = builder(data, environment=environment)
+        xml = evento.to_xml()
+        # Guard: never return XML that is not well-formed.
+        try:
+            etree.fromstring(xml.encode("utf-8") if isinstance(xml, str) else xml)
+        except (etree.XMLSyntaxError, ValueError) as exc:
+            raise UserError(
+                _(
+                    "Falha ao gerar o XML do evento %(tipo)s: o conteúdo gerado "
+                    "não é um XML válido (%(erro)s)."
+                )
+                % {"tipo": event_type, "erro": exc}
+            ) from exc
+        return xml
+
     def _gerar_xml(self):
         """Generate XML for this intermediary record."""
         self.ensure_one()
         self._check_esociallib()
         data = self._to_esociallib_dict()
         environment = self._get_tp_amb()
+        event_type = self._get_event_type()
         try:
-            xml = to_xml(self._get_event_type(), data, environment=environment)
+            xml = to_xml(event_type, data, environment=environment)
         except FileNotFoundError:
-            # XSD schemas not available — generate without validation
-            from esociallib.generator import _BUILDERS, _ensure_builders_loaded
-
-            _ensure_builders_loaded()
-            builder = _BUILDERS.get(self._get_event_type())
-            if builder is None:
-                raise
-            evento = builder(data, environment=environment)
-            xml = evento.to_xml()
-            _logger.warning("XSD schemas not found — XML generated without validation")
+            xml = self._gerar_xml_sem_validacao(event_type, data, environment)
         return xml
+
+    @api.model
+    def _extract_id_evento(self, xml):
+        """Extract the eSocial event ``Id`` attribute from generated XML.
+
+        The eSocial layout always wraps the event element as
+        ``<eSocial><evtXxx Id="ID...">``, so the Id is the ``Id`` attribute of
+        the first child element of the root. Returns ``False`` when it cannot
+        be found (never raises, so it never blocks event creation).
+        """
+        if not xml:
+            return False
+        try:
+            root = etree.fromstring(
+                xml.encode("utf-8") if isinstance(xml, str) else xml
+            )
+        except (etree.XMLSyntaxError, ValueError):
+            _logger.warning(
+                "eSocial: não foi possível parsear o XML para extrair o Id."
+            )
+            return False
+        for child in root:
+            id_evento = child.get("Id")
+            if id_evento:
+                return id_evento
+        return root.get("Id") or False
 
     def action_gerar_evento(self):
         """Generate XML and create evento record."""
         self.ensure_one()
         xml = self._gerar_xml()
+        id_evento = self._extract_id_evento(xml)
+        if not id_evento:
+            _logger.warning(
+                "eSocial %s: XML gerado sem atributo Id — o retorno do lote não "
+                "poderá casar o evento pelo id_evento.",
+                self._get_event_type(),
+            )
         evento = self.env["l10n_br.esocial.evento"].create(
             {
                 "tipo": self._get_event_type(),
                 "operacao": "I",
+                "id_evento": id_evento,
                 "xml_envio": xml,
                 "company_id": self.company_id.id,
                 "origem_model": self._name,

--- a/l10n_br_esocial/models/intermediarios/s1000_empregador.py
+++ b/l10n_br_esocial/models/intermediarios/s1000_empregador.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import _, fields, models
 from odoo.exceptions import UserError
 

--- a/l10n_br_esocial/models/intermediarios/s1010_rubrica.py
+++ b/l10n_br_esocial/models/intermediarios/s1010_rubrica.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import fields, models
 from odoo.exceptions import UserError
 

--- a/l10n_br_esocial/models/intermediarios/s1020_lotacao.py
+++ b/l10n_br_esocial/models/intermediarios/s1020_lotacao.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import _, fields, models
 from odoo.exceptions import UserError
 

--- a/l10n_br_esocial/models/intermediarios/s1200_remuneracao.py
+++ b/l10n_br_esocial/models/intermediarios/s1200_remuneracao.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import _, fields, models
 from odoo.exceptions import UserError
 
@@ -32,6 +35,20 @@ class ESocialS1200(models.Model):
         default="1",
         required=True,
     )
+    ind_retif = fields.Selection(
+        [
+            ("1", "Original"),
+            ("2", "Retificação"),
+        ],
+        string="Indicativo Retificação",
+        default="1",
+        required=True,
+    )
+    nr_recibo = fields.Char(
+        string="Nº Recibo",
+        help="Número do recibo do evento a ser retificado. "
+        "Obrigatório quando Indicativo de Retificação for 'Retificação'.",
+    )
 
     def _get_event_type(self):
         return "S-1200"
@@ -46,6 +63,9 @@ class ESocialS1200(models.Model):
                 if not rule.l10n_br_esocial_nat_rubr_id:
                     continue
                 if not rule.l10n_br_esocial_cod_rubr:
+                    continue
+                # Skip zero-valued lines — they must not be reported.
+                if not line.total:
                     continue
                 itens.append(
                     {
@@ -69,6 +89,11 @@ class ESocialS1200(models.Model):
         cpf_limpo = "".join(c for c in cpf if c.isdigit())
 
         matricula = employee.l10n_br_esocial_matricula
+        if not matricula:
+            raise UserError(
+                _("Empregado '%(name)s' não possui Matrícula eSocial configurada.")
+                % {"name": employee.name}
+            )
         categoria = employee.l10n_br_esocial_categoria_id
         if not categoria:
             raise UserError(
@@ -96,13 +121,22 @@ class ESocialS1200(models.Model):
 
         cod_lotacao = company.l10n_br_esocial_cod_lotacao or "1"
 
+        ind_retif = int(self.ind_retif)
+        if ind_retif == 2 and not self.nr_recibo:
+            raise UserError(
+                _(
+                    "Retificação (ind_retif=2) exige o Nº do Recibo do evento "
+                    "original a ser retificado."
+                )
+            )
+
         data = {
             "tp_insc": ide["tp_insc"],
             "nr_insc": ide["nr_insc"],
             "cpf_trab": cpf_limpo,
             "ind_apuracao": int(self.ind_apuracao),
             "per_apur": self.per_apur,
-            "ind_retif": 1,
+            "ind_retif": ind_retif,
             "proc_emi": proc["proc_emi"],
             "ver_proc": proc["ver_proc"],
             "dm_dev": [
@@ -127,5 +161,8 @@ class ESocialS1200(models.Model):
                 }
             ],
         }
+
+        if ind_retif == 2:
+            data["nr_recibo"] = self.nr_recibo
 
         return data

--- a/l10n_br_esocial/models/intermediarios/s2200_admissao.py
+++ b/l10n_br_esocial/models/intermediarios/s2200_admissao.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import _, fields, models
 from odoo.exceptions import UserError
 

--- a/l10n_br_esocial/models/intermediarios/s2206_alt_contratual.py
+++ b/l10n_br_esocial/models/intermediarios/s2206_alt_contratual.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import _, fields, models
 from odoo.exceptions import UserError
 

--- a/l10n_br_esocial/models/intermediarios/s2230_afastamento.py
+++ b/l10n_br_esocial/models/intermediarios/s2230_afastamento.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import _, fields, models
 from odoo.exceptions import UserError
 

--- a/l10n_br_esocial/models/intermediarios/s2299_desligamento.py
+++ b/l10n_br_esocial/models/intermediarios/s2299_desligamento.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import _, fields, models
 from odoo.exceptions import UserError
 

--- a/l10n_br_esocial/models/res_company.py
+++ b/l10n_br_esocial/models/res_company.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import fields, models
 
 

--- a/l10n_br_esocial/models/tabelas/__init__.py
+++ b/l10n_br_esocial/models/tabelas/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from . import esocial_tabela_mixin
 from . import esocial_tab_cadastro
 from . import esocial_tab_contribuicao

--- a/l10n_br_esocial/models/tabelas/esocial_tab_acidente.py
+++ b/l10n_br_esocial/models/tabelas/esocial_tab_acidente.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import fields, models
 
 

--- a/l10n_br_esocial/models/tabelas/esocial_tab_cadastro.py
+++ b/l10n_br_esocial/models/tabelas/esocial_tab_cadastro.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import fields, models
 
 

--- a/l10n_br_esocial/models/tabelas/esocial_tab_contribuicao.py
+++ b/l10n_br_esocial/models/tabelas/esocial_tab_contribuicao.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import api, fields, models
 
 

--- a/l10n_br_esocial/models/tabelas/esocial_tab_referencia.py
+++ b/l10n_br_esocial/models/tabelas/esocial_tab_referencia.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import api, fields, models
 
 

--- a/l10n_br_esocial/models/tabelas/esocial_tab_rescisao.py
+++ b/l10n_br_esocial/models/tabelas/esocial_tab_rescisao.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import fields, models
 
 

--- a/l10n_br_esocial/models/tabelas/esocial_tab_saude.py
+++ b/l10n_br_esocial/models/tabelas/esocial_tab_saude.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import fields, models
 
 

--- a/l10n_br_esocial/models/tabelas/esocial_tab_totalizador.py
+++ b/l10n_br_esocial/models/tabelas/esocial_tab_totalizador.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import models
 
 

--- a/l10n_br_esocial/models/tabelas/esocial_tab_trabalho.py
+++ b/l10n_br_esocial/models/tabelas/esocial_tab_trabalho.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import fields, models
 
 

--- a/l10n_br_esocial/models/tabelas/esocial_tabela_mixin.py
+++ b/l10n_br_esocial/models/tabelas/esocial_tabela_mixin.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import api, fields, models
 
 

--- a/l10n_br_esocial/tests/__init__.py
+++ b/l10n_br_esocial/tests/__init__.py
@@ -1,6 +1,10 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from . import test_esocial_tabelas
 from . import test_salary_rule_esocial
 from . import test_esocial_evento
 from . import test_s1010_xml
 from . import test_s1200_xml
 from . import test_intermediarios
+from . import test_rf14_id_evento

--- a/l10n_br_esocial/tests/test_esocial_evento.py
+++ b/l10n_br_esocial/tests/test_esocial_evento.py
@@ -1,9 +1,19 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
 
 
 class TestESocialEvento(TransactionCase):
     """Testes da máquina de estados do evento eSocial."""
+
+    def setUp(self):
+        super().setUp()
+        # action_mark_error/success now require the payroll manager group.
+        self.env.user.groups_id = [
+            (4, self.env.ref("payroll.group_payroll_manager").id)
+        ]
 
     def _create_evento(self, **kwargs):
         vals = {

--- a/l10n_br_esocial/tests/test_esocial_tabelas.py
+++ b/l10n_br_esocial/tests/test_esocial_tabelas.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo.tests.common import TransactionCase
 
 

--- a/l10n_br_esocial/tests/test_intermediarios.py
+++ b/l10n_br_esocial/tests/test_intermediarios.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 import logging
 
 from odoo.exceptions import UserError

--- a/l10n_br_esocial/tests/test_rf14_id_evento.py
+++ b/l10n_br_esocial/tests/test_rf14_id_evento.py
@@ -1,0 +1,277 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import logging
+from unittest import mock
+
+from odoo.exceptions import UserError
+from odoo.tests.common import TransactionCase
+
+_logger = logging.getLogger(__name__)
+
+try:
+    import esociallib  # noqa: F401
+
+    HAS_ESOCIALLIB = True
+except ImportError:
+    HAS_ESOCIALLIB = False
+
+
+class _FakeEventoResult:
+    def __init__(self, event_id, aceito=True, nr_recibo=None, code=None, desc=None):
+        self.event_id = event_id
+        self.aceito = aceito
+        self.nr_recibo = nr_recibo
+        self.code = code
+        self.description = desc
+
+
+class _FakeLoteResult:
+    def __init__(self, status="processado", eventos=None):
+        self.status = status
+        self.eventos = eventos or []
+
+
+class TestRF14IdEvento(TransactionCase):
+    """RF-14: id_evento deve ser preenchido na geração e casar no retorno."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.company
+        partner = cls.company.partner_id
+        if not partner.cnpj_cpf:
+            partner.write({"cnpj_cpf": "02.546.716/0001-46"})
+        cls.class_trib = cls.env.ref("l10n_br_esocial.class_trib_01")
+        cls.company.write({"l10n_br_esocial_class_trib_id": cls.class_trib.id})
+
+    # ── _extract_id_evento (unit, sem esociallib) ──────────────────────────
+
+    def test_extract_id_evento_from_xml(self):
+        """Deve extrair o atributo Id do elemento-evento (filho de eSocial)."""
+        base = self.env["l10n_br.esocial.base.intermediario"]
+        xml = (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<eSocial xmlns="http://www.esocial.gov.br/schema/evt/evtRemun/'
+            'v_S_01_03_00">'
+            '<evtRemun Id="ID1123456780000002024031512300000001">'
+            "<ideEvento/></evtRemun></eSocial>"
+        )
+        self.assertEqual(
+            base._extract_id_evento(xml),
+            "ID1123456780000002024031512300000001",
+        )
+
+    def test_extract_id_evento_invalid_xml(self):
+        """XML inválido/ausente deve retornar False (nunca levantar)."""
+        base = self.env["l10n_br.esocial.base.intermediario"]
+        self.assertFalse(base._extract_id_evento("not xml <<<"))
+        self.assertFalse(base._extract_id_evento(""))
+        self.assertFalse(base._extract_id_evento(False))
+
+    # ── geração preenche id_evento (requer esociallib) ─────────────────────
+
+    def test_gerar_evento_preenche_id_evento(self):
+        """action_gerar_evento deve preencher id_evento com o Id do XML."""
+        if not HAS_ESOCIALLIB:
+            self.skipTest("esociallib não instalada")
+        s1000 = self.env["l10n_br.esocial.s1000"].create(
+            {
+                "operacao": "inclusao",
+                "ini_valid": "2024-01",
+                "company_id": self.company.id,
+            }
+        )
+        evento = s1000.action_gerar_evento()
+        self.assertTrue(evento.id_evento, "id_evento deve estar preenchido")
+        self.assertEqual(len(evento.id_evento), 36)
+        self.assertTrue(evento.id_evento.startswith("ID"))
+        # O id_evento deve bater exatamente com o Id presente no XML gerado.
+        id_from_xml = self.env[
+            "l10n_br.esocial.base.intermediario"
+        ]._extract_id_evento(evento.xml_envio)
+        self.assertEqual(evento.id_evento, id_from_xml)
+
+    # ── matching do retorno casa pelo id_evento ────────────────────────────
+
+    def test_retorno_casa_por_id_evento_aceito(self):
+        """Retorno com event_id igual ao id_evento deve casar e criar recibo."""
+        evento = self.env["l10n_br.esocial.evento"].create(
+            {
+                "tipo": "S-1200",
+                "operacao": "I",
+                "id_evento": "ID1123456780000002024031512300000001",
+                "state": "sent",
+                "company_id": self.company.id,
+            }
+        )
+        lote = self.env["l10n_br.esocial.lote"].create(
+            {"company_id": self.company.id, "protocolo": "PROT-1"}
+        )
+        evento.lote_id = lote.id
+
+        fake = _FakeLoteResult(
+            eventos=[
+                _FakeEventoResult(
+                    event_id="ID1123456780000002024031512300000001",
+                    aceito=True,
+                    nr_recibo="1.2.202403.0000001",
+                )
+            ]
+        )
+        with mock.patch(
+            "odoo.addons.l10n_br_esocial.models.esocial_lote.consultar_lote",
+            return_value=fake,
+        ), mock.patch.object(
+            type(lote), "_get_certificate", return_value=(b"", "")
+        ):
+            lote.action_consultar()
+
+        self.assertEqual(evento.state, "success")
+        self.assertEqual(evento.nr_recibo, "1.2.202403.0000001")
+        self.assertEqual(lote.state, "done")
+
+    def test_retorno_rejeitado_cria_ocorrencia(self):
+        """Retorno rejeitado deve marcar erro e criar ocorrência."""
+        evento = self.env["l10n_br.esocial.evento"].create(
+            {
+                "tipo": "S-1200",
+                "operacao": "I",
+                "id_evento": "ID9999",
+                "state": "sent",
+                "company_id": self.company.id,
+            }
+        )
+        lote = self.env["l10n_br.esocial.lote"].create(
+            {"company_id": self.company.id, "protocolo": "PROT-2"}
+        )
+        evento.lote_id = lote.id
+        fake = _FakeLoteResult(
+            eventos=[
+                _FakeEventoResult(
+                    event_id="ID9999",
+                    aceito=False,
+                    code="301",
+                    desc="Erro de validação",
+                )
+            ]
+        )
+        with mock.patch(
+            "odoo.addons.l10n_br_esocial.models.esocial_lote.consultar_lote",
+            return_value=fake,
+        ), mock.patch.object(
+            type(lote), "_get_certificate", return_value=(b"", "")
+        ):
+            lote.action_consultar()
+
+        self.assertEqual(evento.state, "error")
+        self.assertEqual(lote.state, "error")
+        self.assertEqual(len(evento.ocorrencia_ids), 1)
+        self.assertEqual(evento.ocorrencia_ids.codigo, "301")
+
+    def test_retorno_id_nao_casa_nao_altera_evento(self):
+        """event_id que não casa não deve alterar nenhum evento."""
+        evento = self.env["l10n_br.esocial.evento"].create(
+            {
+                "tipo": "S-1200",
+                "operacao": "I",
+                "id_evento": "ID-CORRETO",
+                "state": "sent",
+                "company_id": self.company.id,
+            }
+        )
+        lote = self.env["l10n_br.esocial.lote"].create(
+            {"company_id": self.company.id, "protocolo": "PROT-3"}
+        )
+        evento.lote_id = lote.id
+        fake = _FakeLoteResult(
+            eventos=[_FakeEventoResult(event_id="ID-DIFERENTE", aceito=True)]
+        )
+        with mock.patch(
+            "odoo.addons.l10n_br_esocial.models.esocial_lote.consultar_lote",
+            return_value=fake,
+        ), mock.patch.object(
+            type(lote), "_get_certificate", return_value=(b"", "")
+        ):
+            lote.action_consultar()
+
+        self.assertEqual(evento.state, "sent")
+        self.assertFalse(evento.nr_recibo)
+
+
+class TestRF25LoteHomogeneidade(TransactionCase):
+    """RF-25: lote deve ser homogêneo por grupo eSocial."""
+
+    def setUp(self):
+        super().setUp()
+        self.lote = self.env["l10n_br.esocial.lote"].create(
+            {"company_id": self.env.company.id}
+        )
+
+    def _evento(self, tipo):
+        return self.env["l10n_br.esocial.evento"].create(
+            {
+                "tipo": tipo,
+                "operacao": "I",
+                "state": "validated",
+                "company_id": self.env.company.id,
+                "lote_id": self.lote.id,
+            }
+        )
+
+    def test_classify_grupo(self):
+        self.assertEqual(self.lote._classify_grupo("S-1000"), 1)
+        self.assertEqual(self.lote._classify_grupo("S-1010"), 1)
+        self.assertEqual(self.lote._classify_grupo("S-2200"), 2)
+        self.assertEqual(self.lote._classify_grupo("S-3000"), 2)
+        self.assertEqual(self.lote._classify_grupo("S-1200"), 3)
+        self.assertEqual(self.lote._classify_grupo("S-1299"), 3)
+
+    def test_lote_homogeneo_ok(self):
+        eventos = self._evento("S-1000") + self._evento("S-1010")
+        self.assertEqual(self.lote._get_lote_grupo(eventos), 1)
+
+    def test_lote_grupos_mistos_bloqueia(self):
+        eventos = self._evento("S-1010") + self._evento("S-1200")
+        with self.assertRaises(UserError):
+            self.lote._get_lote_grupo(eventos)
+
+
+class TestRF25AuditoriaGuarda(TransactionCase):
+    """RF-25: forçar estado exige grupo manager e registra no chatter."""
+
+    def setUp(self):
+        super().setUp()
+        self.evento = self.env["l10n_br.esocial.evento"].create(
+            {
+                "tipo": "S-1200",
+                "operacao": "I",
+                "company_id": self.env.company.id,
+            }
+        )
+        self.manager_group = self.env.ref("payroll.group_payroll_manager")
+
+    def test_mark_success_sem_grupo_bloqueia(self):
+        user = self.env["res.users"].create(
+            {
+                "name": "eSocial User",
+                "login": "esocial_user_no_mgr",
+                "groups_id": [(6, 0, [self.env.ref("base.group_user").id])],
+            }
+        )
+        with self.assertRaises(UserError):
+            self.evento.with_user(user).action_mark_success()
+
+    def test_mark_success_com_grupo_registra_chatter(self):
+        self.env.user.groups_id = [(4, self.manager_group.id)]
+        n_before = len(self.evento.message_ids)
+        self.evento.action_mark_success()
+        self.assertEqual(self.evento.state, "success")
+        self.assertGreater(len(self.evento.message_ids), n_before)
+
+    def test_mark_error_com_grupo_registra_chatter(self):
+        self.env.user.groups_id = [(4, self.manager_group.id)]
+        n_before = len(self.evento.message_ids)
+        self.evento.action_mark_error()
+        self.assertEqual(self.evento.state, "error")
+        self.assertGreater(len(self.evento.message_ids), n_before)

--- a/l10n_br_esocial/tests/test_s1010_xml.py
+++ b/l10n_br_esocial/tests/test_s1010_xml.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 import logging
 
 from odoo.exceptions import UserError

--- a/l10n_br_esocial/tests/test_s1200_xml.py
+++ b/l10n_br_esocial/tests/test_s1200_xml.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 import logging
 
 from odoo.exceptions import UserError
@@ -36,6 +39,15 @@ class TestS1200XML(TransactionCase):
                 "cnpj_cpf": "076.166.929-41",
                 "l10n_br_esocial_matricula": "MAT001",
                 "l10n_br_esocial_categoria_id": cls.cat_101.id,
+            }
+        )
+        cls.contract = cls.env["hr.contract"].create(
+            {
+                "name": "Contrato Test S1200",
+                "employee_id": cls.employee.id,
+                "wage": 5000.0,
+                "date_start": "2024-01-02",
+                "state": "open",
             }
         )
 
@@ -120,3 +132,106 @@ class TestS1200XML(TransactionCase):
         """hr.payslip deve ter campo l10n_br_esocial_s1200_id."""
         fields = self.env["hr.payslip"]._fields
         self.assertIn("l10n_br_esocial_s1200_id", fields)
+
+    # ── RF-25: robustez do S-1200 ──────────────────────────────────────────
+
+    def _create_payslip_with_lines(self, amounts):
+        """Cria um holerite com uma linha por valor em ``amounts``."""
+        payslip = self.env["hr.payslip"].create(
+            {
+                "name": "Holerite Test",
+                "employee_id": self.employee.id,
+                "contract_id": self.contract.id,
+                "date_from": "2024-03-01",
+                "date_to": "2024-03-31",
+            }
+        )
+        for i, amount in enumerate(amounts):
+            self.env["hr.payslip.line"].create(
+                {
+                    "slip_id": payslip.id,
+                    "salary_rule_id": self.rule.id,
+                    "name": f"Linha {i}",
+                    "code": f"L{i}",
+                    "employee_id": self.employee.id,
+                    "contract_id": self.contract.id,
+                    "quantity": 1,
+                    "amount": amount,
+                    "rate": 100,
+                }
+            )
+        return payslip
+
+    def test_s1200_filtra_linhas_zeradas(self):
+        """Linhas com total == 0 não devem ir para itens_remun."""
+        payslip = self._create_payslip_with_lines([5000.0, 0.0])
+        s1200 = self._create_s1200(payslip_ids=[payslip.id])
+        itens = s1200._build_itens_remun()
+        self.assertEqual(len(itens), 1)
+        self.assertEqual(itens[0]["vr_rubr"], "5000.0")
+
+    def test_s1200_requires_matricula(self):
+        """Deve dar erro se empregado não tem matrícula.
+
+        A validação de matrícula ocorre antes da leitura das linhas, então
+        não é necessário montar holerite para exercitá-la.
+        """
+        emp = self.env["hr.employee"].create(
+            {
+                "name": "No Matricula Worker",
+                "cnpj_cpf": "857.642.960-52",
+                "l10n_br_esocial_categoria_id": self.cat_101.id,
+            }
+        )
+        s1200 = self.env["l10n_br.esocial.s1200"].create(
+            {
+                "employee_id": emp.id,
+                "per_apur": "2024-03",
+                "ind_apuracao": "1",
+                "company_id": self.company.id,
+            }
+        )
+        with self.assertRaises(UserError):
+            s1200._to_esociallib_dict()
+
+    def test_s1200_retificacao_exige_nr_recibo(self):
+        """ind_retif=2 sem nr_recibo deve levantar erro."""
+        payslip = self._create_payslip_with_lines([5000.0])
+        s1200 = self.env["l10n_br.esocial.s1200"].create(
+            {
+                "employee_id": self.employee.id,
+                "payslip_ids": [(6, 0, [payslip.id])],
+                "per_apur": "2024-03",
+                "ind_apuracao": "1",
+                "ind_retif": "2",
+                "company_id": self.company.id,
+            }
+        )
+        with self.assertRaises(UserError):
+            s1200._to_esociallib_dict()
+
+    def test_s1200_retificacao_com_nr_recibo(self):
+        """ind_retif=2 com nr_recibo deve popular o dict corretamente."""
+        payslip = self._create_payslip_with_lines([5000.0])
+        s1200 = self.env["l10n_br.esocial.s1200"].create(
+            {
+                "employee_id": self.employee.id,
+                "payslip_ids": [(6, 0, [payslip.id])],
+                "per_apur": "2024-03",
+                "ind_apuracao": "1",
+                "ind_retif": "2",
+                "nr_recibo": "1.2.202403.0000001",
+                "company_id": self.company.id,
+            }
+        )
+        data = s1200._to_esociallib_dict()
+        self.assertEqual(data["ind_retif"], 2)
+        self.assertEqual(data["nr_recibo"], "1.2.202403.0000001")
+
+    def test_s1200_original_sem_nr_recibo(self):
+        """ind_retif=1 (original) não deve incluir nr_recibo."""
+        payslip = self._create_payslip_with_lines([5000.0])
+        s1200 = self._create_s1200(payslip_ids=[payslip.id])
+        data = s1200._to_esociallib_dict()
+        self.assertEqual(data["ind_retif"], 1)
+        self.assertNotIn("nr_recibo", data)

--- a/l10n_br_esocial/tests/test_salary_rule_esocial.py
+++ b/l10n_br_esocial/tests/test_salary_rule_esocial.py
@@ -1,3 +1,6 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo.tests.common import TransactionCase
 
 


### PR DESCRIPTION
Onda 5 do backlog da folha (PRD). Independente das demais (base 16.0).

## RF-14 (P0) — id_evento
O `id_evento` nunca era preenchido → o matching do retorno do lote (`esocial_lote.py`) nunca casava e os eventos ficavam presos em `sent` sem recibo/ocorrência. Agora o `Id` do evento (atributo `Id` do elemento-evento, 36 chars) é extraído do XML gerado e persistido no `create`; o retorno passa a casar e criar recibo/ocorrência.

## RF-25 — robustez do fluxo existente
- **Lote homogêneo:** `UserError` se misturar grupos (tabelas / não periódicos / periódicos).
- **Transmissão guardada** por try/except (rollback); `state=sent` só após sucesso.
- **S-1200:** filtra linhas `total=0`, valida matrícula ausente, suporta `ind_retif=2` + `nrRecibo` (era hardcodado).
- **Guardas de auditoria** em `action_mark_error/success` (exige manager + chatter).

## P2
- Headers AGPL nos `.py` faltantes; `_()` nas notificações; fallback sem XSD agora loga ERROR e valida XML bem-formado.

## Validação
CI do repo quebrado por infra — validado **localmente**: **80 testes, 0 falha/0 erro**.

## Fora de escopo / pendências (@mileo)
- **Eventos novos** (S-1005, S-1210, S-1299, S-3000, S-5001/2/3): a esociallib 0.1.3 já tem builders/deserialização, mas cada um exige modelo intermediário + mapeamento + views + segurança no Odoo. **Tarefa própria.**
- **XSDs oficiais S-1.3 não vêm na esociallib 0.1.3** (`schemas/v_s13/` só tem README) → hoje o XML é gerado sem validação XSD (agora com log ERROR). Recomendo empacotar os XSDs oficiais antes de transmitir em produção.