### PR TITLE
[FIX] l10n_br_hr_arquivos_governo: rubricas corretas e falha alta em valores zerados

### DIFF
--- a/l10n_br_hr_arquivos_governo/models/__init__.py
+++ b/l10n_br_hr_arquivos_governo/models/__init__.py
@@ -1,4 +1,5 @@
 from . import constantes_rh
+from . import rubricas
 from . import res_company
 from . import l10n_br_hr_dirf
 from . import l10n_br_hr_sefip

--- a/l10n_br_hr_arquivos_governo/models/constantes_rh.py
+++ b/l10n_br_hr_arquivos_governo/models/constantes_rh.py
@@ -1,5 +1,37 @@
 """Constantes para geração de arquivos do governo brasileiro (SEFIP, DIRF, CAGED)."""
 
+# ══════════════════════════════════════════════════════════════════════
+# Códigos das rubricas (hr.salary.rule.code) consumidos pelos geradores.
+#
+# São os códigos REAIS das regras salariais definidas em
+# ``l10n_br_hr_payroll`` (folha mensal e estatutário) e, quando instalado,
+# ``l10n_br_hr_vacation`` (férias, 13º salário e rescisão).
+#
+# A mesma verba tem código diferente conforme a estrutura de cálculo:
+# a folha mensal, as férias e a rescisão usam ``INSS``/``IRRF``, enquanto
+# o 13º salário usa ``INSS_13``/``IRRF_13``.  Por isso cada verba é
+# declarada como uma TUPLA de códigos equivalentes, cujos valores são
+# somados ao compor o arquivo.
+#
+# ATENÇÃO: não existe rubrica com código "BRUTO" na folha brasileira —
+# a remuneração bruta é a regra de código ``GROSS``.
+# ══════════════════════════════════════════════════════════════════════
+
+#: Remuneração bruta (proventos): BASIC + ALW.
+CODIGOS_REMUNERACAO_BRUTA = ("GROSS",)
+
+#: Contribuição previdenciária do segurado (INSS/RPPS), incluindo 13º.
+CODIGOS_INSS = ("INSS", "INSS_13", "CONTRIB_RPPS")
+
+#: Imposto de renda retido na fonte, incluindo 13º.
+CODIGOS_IRRF = ("IRRF", "IRRF_13")
+
+#: FGTS depositado pelo empregador, incluindo 13º.
+CODIGOS_FGTS = ("FGTS", "FGTS_13")
+
+#: Salário líquido.
+CODIGOS_LIQUIDO = ("NET",)
+
 MESES = [
     ("1", "Janeiro"),
     ("2", "Fevereiro"),

--- a/l10n_br_hr_arquivos_governo/models/l10n_br_hr_dirf.py
+++ b/l10n_br_hr_arquivos_governo/models/l10n_br_hr_dirf.py
@@ -1,10 +1,16 @@
 import base64
 import calendar
 import io
+import logging
 import unicodedata
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+
+from .constantes_rh import CODIGOS_INSS, CODIGOS_IRRF, CODIGOS_REMUNERACAO_BRUTA
+from .rubricas import somar_rubricas
+
+_logger = logging.getLogger(__name__)
 
 
 def _normalize(text, size=0, fill=" "):
@@ -134,13 +140,14 @@ class HrDirf(models.Model):
             )
         return self.env["hr.payslip"].search(domain)
 
-    def _get_line_total(self, payslips, code):
-        """Soma o total de uma rubrica nos holerites."""
-        total = 0.0
-        for payslip in payslips:
-            for line in payslip.line_ids:
-                if line.code == code:
-                    total += line.total
+    def _get_line_total(self, payslips, codigos):
+        """Soma o total de uma rubrica nos holerites.
+
+        ``codigos`` pode ser um código único ou uma coleção de códigos
+        equivalentes (ex.: ``INSS`` na folha mensal e ``INSS_13`` no 13º).
+        Holerites sem nenhuma linha com esses códigos geram aviso no log.
+        """
+        total, _faltantes = somar_rubricas(payslips, codigos, origem="DIRF")
         return total
 
     def _generate_header(self):
@@ -175,8 +182,12 @@ class HrDirf(models.Model):
         )
         return lines
 
-    def _generate_employee_data(self, employee):
-        """Gera dados DIRF de um empregado."""
+    def _generate_employee_data(self, employee, resumo=None):
+        """Gera dados DIRF de um empregado.
+
+        ``resumo`` é um dicionário opcional acumulador usado por
+        :meth:`action_gerar_dirf` para detectar arquivos zerados.
+        """
         lines = []
         payslips = self._get_payslips_employee(employee)
         if not payslips:
@@ -197,22 +208,38 @@ class HrDirf(models.Model):
         )
 
         # RTRT - Rendimentos tributáveis por mês
+        rendimento_ano = 0.0
         for month in range(1, 13):
             month_payslips = self._get_payslips_employee(employee, month)
-            rendimento = self._get_line_total(month_payslips, "BRUTO")
+            rendimento = self._get_line_total(month_payslips, CODIGOS_REMUNERACAO_BRUTA)
+            rendimento_ano += rendimento
             lines.append("RTRT|%s|" % _format_value(rendimento))
 
         # RTPO - Previdência oficial por mês
         for month in range(1, 13):
             month_payslips = self._get_payslips_employee(employee, month)
-            inss = self._get_line_total(month_payslips, "INSS")
+            inss = self._get_line_total(month_payslips, CODIGOS_INSS)
             lines.append("RTPO|%s|" % _format_value(inss))
 
         # RTDP - IR retido por mês
         for month in range(1, 13):
             month_payslips = self._get_payslips_employee(employee, month)
-            irrf = self._get_line_total(month_payslips, "IRRF")
+            irrf = self._get_line_total(month_payslips, CODIGOS_IRRF)
             lines.append("RTDP|%s|" % _format_value(irrf))
+
+        if not rendimento_ano:
+            _logger.warning(
+                "DIRF %s: rendimento tributável ZERO para %s, apesar de existirem "
+                "%d holerite(s) no ano-calendário. Verifique as rubricas %s.",
+                self.ano_referencia,
+                employee.display_name,
+                len(payslips),
+                "/".join(CODIGOS_REMUNERACAO_BRUTA),
+            )
+
+        if resumo is not None:
+            resumo["payslips"] = resumo.get("payslips", 0) + len(payslips)
+            resumo["rendimento"] = resumo.get("rendimento", 0.0) + rendimento_ano
 
         return lines
 
@@ -223,8 +250,27 @@ class HrDirf(models.Model):
             raise UserError(_("Busque os funcionários antes de gerar a DIRF."))
 
         lines = self._generate_header()
+        resumo = {}
         for employee in self.employee_ids:
-            lines.extend(self._generate_employee_data(employee))
+            lines.extend(self._generate_employee_data(employee, resumo=resumo))
+
+        # Falha alta: com holerites no ano-calendário, uma DIRF integralmente
+        # zerada indica rubrica ausente/errada e não um arquivo válido.
+        if resumo.get("payslips") and not resumo.get("rendimento"):
+            raise UserError(
+                _(
+                    "Nenhum rendimento tributável encontrado nos %(qtd)s holerite(s) "
+                    "do ano-calendário %(ano)s.\n\n"
+                    "A DIRF não foi gerada para evitar um arquivo zerado. "
+                    "Confira se as regras salariais da folha possuem as rubricas "
+                    "%(codigos)s."
+                )
+                % {
+                    "qtd": resumo["payslips"],
+                    "ano": self.ano_calendario,
+                    "codigos": "/".join(CODIGOS_REMUNERACAO_BRUTA),
+                }
+            )
 
         lines.append("FIMDirf|")
         content = "\r\n".join(lines)

--- a/l10n_br_hr_arquivos_governo/models/l10n_br_hr_sefip.py
+++ b/l10n_br_hr_arquivos_governo/models/l10n_br_hr_sefip.py
@@ -9,11 +9,15 @@ from odoo.exceptions import UserError
 from .constantes_rh import (
     CENTRALIZADORA,
     CODIGO_RECOLHIMENTO,
+    CODIGOS_FGTS,
+    CODIGOS_INSS,
+    CODIGOS_REMUNERACAO_BRUTA,
     MESES,
     MODALIDADE_ARQUIVO,
     RECOLHIMENTO_FGTS,
     RECOLHIMENTO_GPS,
 )
+from .rubricas import somar_rubricas
 
 
 def _normalize(text, size, fill=" "):
@@ -156,12 +160,16 @@ class L10nBrHrSefip(models.Model):
             ]
         return self.env["hr.payslip"].search(domain)
 
-    def _get_line_total(self, payslip, code):
-        """Retorna total de uma rubrica no holerite."""
-        for line in payslip.line_ids:
-            if line.code == code:
-                return abs(line.total)
-        return 0.0
+    def _get_line_total(self, payslips, codigos):
+        """Retorna o total de uma rubrica nos holerites.
+
+        ``codigos`` pode ser um código único ou uma coleção de códigos
+        equivalentes (ex.: ``INSS`` na folha mensal e ``INSS_13`` no 13º,
+        somados quando ambos existem, como na rescisão).  Holerites sem
+        nenhuma linha com esses códigos geram aviso explícito no log.
+        """
+        total, _faltantes = somar_rubricas(payslips, codigos, origem="SEFIP")
+        return abs(total)
 
     def _generate_reg00(self):
         """Registro 00 - Header."""
@@ -210,12 +218,14 @@ class L10nBrHrSefip(models.Model):
         lines.append(self._generate_reg10())
 
         # Registro 30 - Trabalhadores (simplificado)
+        total_remuneracao = 0.0
         for payslip in payslips:
             employee = payslip.employee_id
             pis = (employee.pis_pasep or "").replace(".", "").replace("-", "")
-            remuneracao = self._get_line_total(payslip, "BRUTO")
-            inss_desc = self._get_line_total(payslip, "INSS")
-            fgts = self._get_line_total(payslip, "FGTS")
+            remuneracao = self._get_line_total(payslip, CODIGOS_REMUNERACAO_BRUTA)
+            inss_desc = self._get_line_total(payslip, CODIGOS_INSS)
+            fgts = self._get_line_total(payslip, CODIGOS_FGTS)
+            total_remuneracao += remuneracao
 
             line = (
                 "30"
@@ -228,6 +238,25 @@ class L10nBrHrSefip(models.Model):
                 + " " * 50  # complemento
             )
             lines.append(line)
+
+        # Falha alta: SEFIP com remuneração total zerada em todos os
+        # trabalhadores indica rubrica ausente/errada, não arquivo válido.
+        if not total_remuneracao:
+            raise UserError(
+                _(
+                    "Nenhuma remuneração encontrada nos %(qtd)s holerite(s) da "
+                    "competência %(mes)s/%(ano)s.\n\n"
+                    "O SEFIP não foi gerado para evitar um arquivo zerado. "
+                    "Confira se as regras salariais da folha possuem as rubricas "
+                    "%(codigos)s."
+                )
+                % {
+                    "qtd": len(payslips),
+                    "mes": self.mes,
+                    "ano": self.ano,
+                    "codigos": "/".join(CODIGOS_REMUNERACAO_BRUTA),
+                }
+            )
 
         content = "\r\n".join(lines)
         buf = io.BytesIO()

--- a/l10n_br_hr_arquivos_governo/models/rubricas.py
+++ b/l10n_br_hr_arquivos_governo/models/rubricas.py
@@ -1,0 +1,52 @@
+"""Leitura das rubricas (linhas de holerite) usadas nos arquivos do governo.
+
+Centraliza a busca de valores por código de regra salarial para que um
+código inexistente NÃO gere silenciosamente um arquivo zerado: sempre que
+um holerite não possui nenhuma linha com os códigos esperados, um aviso
+explícito é registrado no log.
+"""
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def normalizar_codigos(codigos):
+    """Aceita um código único (str) ou uma coleção de códigos equivalentes."""
+    if isinstance(codigos, str):
+        return (codigos,)
+    return tuple(codigos)
+
+
+def somar_rubricas(payslips, codigos, origem="Arquivos do Governo"):
+    """Soma o total das linhas cujo ``code`` está em ``codigos``.
+
+    :param payslips: recordset de ``hr.payslip`` (pode estar vazio).
+    :param codigos: código (str) ou coleção de códigos equivalentes.
+    :param origem: identificação do gerador, usada nas mensagens de log.
+    :return: tupla ``(total, holerites_sem_a_rubrica)``.
+
+    Quando um holerite não possui nenhuma linha com os códigos informados o
+    valor dele é 0,00 e o holerite entra em ``holerites_sem_a_rubrica``; um
+    aviso é gravado no log para que o zero não passe despercebido.
+    """
+    codigos = normalizar_codigos(codigos)
+    total = 0.0
+    faltantes = payslips.browse()
+    for payslip in payslips:
+        linhas = payslip.line_ids.filtered(lambda line: line.code in codigos)
+        if not linhas:
+            faltantes |= payslip
+            continue
+        total += sum(linhas.mapped("total"))
+    if faltantes:
+        _logger.warning(
+            "%s: nenhuma linha com o(s) código(s) %s encontrada em %d holerite(s) "
+            "(%s). O valor foi gravado como ZERO no arquivo — confira os códigos "
+            "das regras salariais (hr.salary.rule) da estrutura utilizada.",
+            origem,
+            "/".join(codigos),
+            len(faltantes),
+            ", ".join(faltantes.mapped("display_name")[:10]),
+        )
+    return total, faltantes

--- a/l10n_br_hr_arquivos_governo/tests/test_arquivos_governo.py
+++ b/l10n_br_hr_arquivos_governo/tests/test_arquivos_governo.py
@@ -1,15 +1,163 @@
 from odoo.exceptions import UserError
+from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
 
+from ..models.constantes_rh import (
+    CODIGOS_FGTS,
+    CODIGOS_INSS,
+    CODIGOS_IRRF,
+    CODIGOS_REMUNERACAO_BRUTA,
+)
 
-class TestDirf(TransactionCase):
+#: Salário do contrato de teste: sem adicionais nem salário-família,
+#: a remuneração bruta (GROSS) é exatamente este valor.
+SALARIO_TESTE = 5000.00
+
+#: Logger onde os avisos de rubrica ausente são registrados.
+LOGGER_RUBRICAS = "odoo.addons.l10n_br_hr_arquivos_governo.models.rubricas"
+
+
+class ArquivosGovernoCommon(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(
+            context=dict(
+                cls.env.context,
+                tracking_disable=True,
+                test_queue_job_no_delay=True,
+            )
+        )
         cls.company = cls.env.ref("base.main_company")
         cls.employee = cls.env.ref("l10n_br_hr.demo_employee_joao")
         cls.contract = cls.env.ref("l10n_br_hr_contract.demo_contract_joao")
+        cls.struct_clt = cls.env.ref("l10n_br_hr_payroll.structure_clt")
+        cls.cat_gross = cls.env.ref("l10n_br_hr_payroll.hr_salary_rule_category_gross")
+        cls.cat_ded = cls.env.ref("l10n_br_hr_payroll.hr_salary_rule_category_ded")
+        cls.cat_comp = cls.env.ref("l10n_br_hr_payroll.hr_salary_rule_category_comp")
 
+        # Empregado/contrato determinístico: nenhum adicional, nenhum
+        # dependente e nenhum filho para salário-família, de modo que
+        # GROSS == SALARIO_TESTE.
+        cls.employee_valor = cls.env["hr.employee"].create(
+            {
+                "name": "Funcionario Valor Conhecido",
+                "company_id": cls.company.id,
+                "country_id": cls.env.ref("base.br").id,
+                "l10n_br_tipo_contrato": "clt",
+                "l10n_br_irrf_dependentes": 0,
+                "l10n_br_num_filhos_sf": 0,
+            }
+        )
+        cls.contract_valor = cls.env["hr.contract"].create(
+            {
+                "name": "Contrato Valor Conhecido",
+                "employee_id": cls.employee_valor.id,
+                "company_id": cls.company.id,
+                "wage": SALARIO_TESTE,
+                "date_start": "2024-01-02",
+                "state": "open",
+                "struct_id": cls.struct_clt.id,
+            }
+        )
+
+    @classmethod
+    def _criar_holerite(
+        cls,
+        contract,
+        date_from,
+        date_to,
+        struct=None,
+        name="Holerite Teste",
+    ):
+        """Cria, calcula e fecha um holerite."""
+        payslip = cls.env["hr.payslip"].create(
+            {
+                "name": name,
+                "employee_id": contract.employee_id.id,
+                "contract_id": contract.id,
+                "struct_id": (struct or contract.struct_id).id,
+                "date_from": date_from,
+                "date_to": date_to,
+            }
+        )
+        payslip.compute_sheet()
+        payslip.action_payslip_done()
+        return payslip
+
+    @classmethod
+    def _criar_estrutura_13(cls):
+        """Estrutura de 13º salário com valores fixos e códigos do 13º.
+
+        Reproduz os códigos usados em ``l10n_br_hr_vacation``
+        (GROSS / INSS_13 / IRRF_13 / FGTS) sem depender daquele módulo.
+        """
+
+        def _regra(name, code, category, valor, sequence):
+            return cls.env["hr.salary.rule"].create(
+                {
+                    "name": name,
+                    "code": code,
+                    "sequence": sequence,
+                    "category_id": category.id,
+                    "condition_select": "none",
+                    "amount_select": "fix",
+                    "amount_fix": valor,
+                }
+            )
+
+        regras = (
+            _regra("13 Bruto", "GROSS", cls.cat_gross, SALARIO_TESTE, 99)
+            | _regra("13 INSS", "INSS_13", cls.cat_ded, 400.0, 100)
+            | _regra("13 IRRF", "IRRF_13", cls.cat_ded, 100.0, 120)
+            | _regra("13 FGTS", "FGTS", cls.cat_comp, 400.0, 150)
+        )
+        return cls.env["hr.payroll.structure"].create(
+            {
+                "name": "13o Salario (Teste)",
+                "code": "TESTE_13",
+                "company_id": cls.company.id,
+                "rule_ids": [(6, 0, regras.ids)],
+            }
+        )
+
+    @classmethod
+    def _criar_estrutura_sem_bruto(cls):
+        """Estrutura sem nenhuma rubrica de remuneração bruta."""
+        regra = cls.env["hr.salary.rule"].create(
+            {
+                "name": "Verba Desconhecida",
+                "code": "VERBA_INEXISTENTE",
+                "sequence": 10,
+                "category_id": cls.cat_ded.id,
+                "condition_select": "none",
+                "amount_select": "fix",
+                "amount_fix": 100.0,
+            }
+        )
+        return cls.env["hr.payroll.structure"].create(
+            {
+                "name": "Estrutura sem bruto (Teste)",
+                "code": "TESTE_SEM_BRUTO",
+                "company_id": cls.company.id,
+                "rule_ids": [(6, 0, regra.ids)],
+            }
+        )
+
+    @staticmethod
+    def _centavos(valor, size=15):
+        """Mesma formatação usada nos arquivos: centavos com zeros à esquerda."""
+        return str(int(round(abs(valor) * 100, 0))).zfill(size)
+
+    @staticmethod
+    def _valor_rubrica(payslip, codigos):
+        """Total das linhas do holerite com os códigos informados."""
+        linhas = payslip.line_ids.filtered(lambda line: line.code in codigos)
+        return sum(linhas.mapped("total"))
+
+
+@tagged("post_install", "-at_install")
+class TestDirf(ArquivosGovernoCommon):
     def _create_dirf(self, **kwargs):
         vals = {
             "company_id": self.company.id,
@@ -43,18 +191,9 @@ class TestDirf(TransactionCase):
 
     def test_dirf_buscar_e_gerar(self):
         """Busca funcionários e gera DIRF com holerite existente."""
-        payslip = self.env["hr.payslip"].create(
-            {
-                "employee_id": self.employee.id,
-                "contract_id": self.contract.id,
-                "struct_id": self.contract.struct_id.id,
-                "date_from": "2024-01-01",
-                "date_to": "2024-01-31",
-                "name": "Holerite DIRF Test",
-            }
+        self._criar_holerite(
+            self.contract, "2024-01-01", "2024-01-31", name="Holerite DIRF Test"
         )
-        payslip.compute_sheet()
-        payslip.action_payslip_done()
 
         dirf = self._create_dirf()
         dirf.action_buscar_funcionarios()
@@ -73,15 +212,90 @@ class TestDirf(TransactionCase):
         self.assertTrue(dirf.retificadora)
         self.assertEqual(dirf.numero_recibo, "12345")
 
+    def test_dirf_valores_mensais(self):
+        """RTRT/RTPO/RTDP devem trazer os VALORES do holerite, não zeros."""
+        payslip = self._criar_holerite(
+            self.contract_valor, "2024-03-01", "2024-03-31", name="Holerite 03/2024"
+        )
+        bruto = self._valor_rubrica(payslip, CODIGOS_REMUNERACAO_BRUTA)
+        inss = self._valor_rubrica(payslip, CODIGOS_INSS)
+        irrf = self._valor_rubrica(payslip, CODIGOS_IRRF)
+        # Pré-condições: as rubricas existem e têm valor.
+        self.assertEqual(bruto, SALARIO_TESTE)
+        self.assertGreater(inss, 0.0)
+        self.assertGreater(irrf, 0.0)
 
-class TestSefip(TransactionCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.company = cls.env.ref("base.main_company")
-        cls.employee = cls.env.ref("l10n_br_hr.demo_employee_joao")
-        cls.contract = cls.env.ref("l10n_br_hr_contract.demo_contract_joao")
+        dirf = self._create_dirf()
+        dirf.employee_ids = self.employee_valor
+        dirf.action_gerar_dirf()
 
+        linhas = dirf.file_content.split("\r\n")
+        rtrt = [line for line in linhas if line.startswith("RTRT|")]
+        rtpo = [line for line in linhas if line.startswith("RTPO|")]
+        rtdp = [line for line in linhas if line.startswith("RTDP|")]
+        self.assertEqual(len(rtrt), 12)
+        self.assertEqual(len(rtpo), 12)
+        self.assertEqual(len(rtdp), 12)
+
+        # Março (índice 2) traz os valores; os demais meses ficam zerados.
+        self.assertEqual(rtrt[2], "RTRT|000000000500000|")
+        self.assertEqual(rtrt[2], "RTRT|%s|" % self._centavos(bruto))
+        self.assertEqual(rtpo[2], "RTPO|%s|" % self._centavos(inss))
+        self.assertEqual(rtdp[2], "RTDP|%s|" % self._centavos(irrf))
+        self.assertEqual(rtrt[0], "RTRT|%s|" % ("0" * 15))
+        # Regressão do bug de rubrica inexistente ("BRUTO"): o mês com
+        # holerite não pode sair zerado.
+        self.assertNotEqual(rtrt[2], "RTRT|%s|" % ("0" * 15))
+
+    def test_dirf_valores_13_salario(self):
+        """13º salário: INSS_13/IRRF_13 devem ser somados nos registros."""
+        struct_13 = self._criar_estrutura_13()
+        payslip = self._criar_holerite(
+            self.contract_valor,
+            "2024-12-01",
+            "2024-12-31",
+            struct=struct_13,
+            name="13o Salario 2024",
+        )
+        self.assertEqual(self._valor_rubrica(payslip, CODIGOS_INSS), 400.0)
+        self.assertEqual(self._valor_rubrica(payslip, CODIGOS_IRRF), 100.0)
+
+        dirf = self._create_dirf()
+        dirf.employee_ids = self.employee_valor
+        dirf.action_gerar_dirf()
+
+        linhas = dirf.file_content.split("\r\n")
+        rtrt = [line for line in linhas if line.startswith("RTRT|")]
+        rtpo = [line for line in linhas if line.startswith("RTPO|")]
+        rtdp = [line for line in linhas if line.startswith("RTDP|")]
+        # Dezembro = índice 11
+        self.assertEqual(rtrt[11], "RTRT|000000000500000|")
+        self.assertEqual(rtpo[11], "RTPO|%s|" % self._centavos(400.0))
+        self.assertEqual(rtdp[11], "RTDP|%s|" % self._centavos(100.0))
+
+    def test_dirf_rubrica_bruta_ausente_falha_alto(self):
+        """Sem rubrica de remuneração bruta: aviso no log e UserError."""
+        struct = self._criar_estrutura_sem_bruto()
+        self._criar_holerite(
+            self.contract_valor,
+            "2024-04-01",
+            "2024-04-30",
+            struct=struct,
+            name="Holerite sem bruto",
+        )
+        dirf = self._create_dirf()
+        dirf.employee_ids = self.employee_valor
+        with self.assertLogs(LOGGER_RUBRICAS, level="WARNING") as log:
+            with self.assertRaises(UserError):
+                dirf.action_gerar_dirf()
+        self.assertTrue(
+            any("GROSS" in mensagem for mensagem in log.output),
+            "O aviso de rubrica ausente deve citar o código GROSS.",
+        )
+
+
+@tagged("post_install", "-at_install")
+class TestSefip(ArquivosGovernoCommon):
     def _create_sefip(self, **kwargs):
         vals = {
             "company_id": self.company.id,
@@ -90,6 +304,12 @@ class TestSefip(TransactionCase):
         }
         vals.update(kwargs)
         return self.env["l10n_br.hr.sefip"].create(vals)
+
+    @staticmethod
+    def _registros_30(sefip):
+        return [
+            line for line in sefip.file_content.split("\r\n") if line.startswith("30")
+        ]
 
     def test_sefip_create(self):
         """Cria registro SEFIP."""
@@ -105,25 +325,16 @@ class TestSefip(TransactionCase):
 
     def test_sefip_gerar_com_holerite(self):
         """Gera SEFIP com holerite existente."""
-        payslip = self.env["hr.payslip"].create(
-            {
-                "employee_id": self.employee.id,
-                "contract_id": self.contract.id,
-                "struct_id": self.contract.struct_id.id,
-                "date_from": "2024-01-01",
-                "date_to": "2024-01-31",
-                "name": "Holerite SEFIP Test",
-            }
+        self._criar_holerite(
+            self.contract, "2024-01-01", "2024-01-31", name="Holerite SEFIP Test"
         )
-        payslip.compute_sheet()
-        payslip.action_payslip_done()
 
         sefip = self._create_sefip()
         sefip.action_gerar_sefip()
         self.assertEqual(sefip.state, "open")
         self.assertTrue(sefip.file_content)
         # Nome é normalizado (sem acentos) no arquivo SEFIP
-        self.assertIn("JOAO", sefip.file_content.upper()[:500])
+        self.assertIn("JOAO", sefip.file_content.upper())
 
     def test_sefip_workflow(self):
         """Testa transições de estado SEFIP."""
@@ -133,15 +344,79 @@ class TestSefip(TransactionCase):
         sefip.action_sent()
         self.assertEqual(sefip.state, "sent")
 
+    def test_sefip_valores_registro_30(self):
+        """Registro 30 deve conter remuneração, INSS e FGTS do holerite."""
+        payslip = self._criar_holerite(
+            self.contract_valor, "2024-02-01", "2024-02-29", name="Holerite 02/2024"
+        )
+        bruto = self._valor_rubrica(payslip, CODIGOS_REMUNERACAO_BRUTA)
+        inss = self._valor_rubrica(payslip, CODIGOS_INSS)
+        fgts = self._valor_rubrica(payslip, CODIGOS_FGTS)
+        self.assertEqual(bruto, SALARIO_TESTE)
+        self.assertGreater(inss, 0.0)
+        self.assertEqual(fgts, SALARIO_TESTE * 0.08)
 
-class TestCaged(TransactionCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.company = cls.env.ref("base.main_company")
-        cls.employee = cls.env.ref("l10n_br_hr.demo_employee_joao")
-        cls.contract = cls.env.ref("l10n_br_hr_contract.demo_contract_joao")
+        sefip = self._create_sefip(mes="2")
+        sefip.action_gerar_sefip()
 
+        registros = self._registros_30(sefip)
+        self.assertEqual(len(registros), 1)
+        registro = registros[0]
+        # Posições do registro 30: "30" + PIS(11) + nome(70) + 3 valores(15)
+        remuneracao_arquivo = registro[83:98]
+        inss_arquivo = registro[98:113]
+        fgts_arquivo = registro[113:128]
+        self.assertEqual(remuneracao_arquivo, "000000000500000")
+        self.assertEqual(remuneracao_arquivo, self._centavos(bruto))
+        self.assertEqual(inss_arquivo, self._centavos(inss))
+        self.assertEqual(fgts_arquivo, self._centavos(fgts))
+        self.assertEqual(fgts_arquivo, "000000000040000")
+        # Regressão do bug de rubrica inexistente ("BRUTO").
+        self.assertNotEqual(remuneracao_arquivo, "0" * 15)
+
+    def test_sefip_valores_13_salario(self):
+        """13º salário: remuneração e INSS_13 entram no registro 30."""
+        struct_13 = self._criar_estrutura_13()
+        self._criar_holerite(
+            self.contract_valor,
+            "2024-12-01",
+            "2024-12-31",
+            struct=struct_13,
+            name="13o Salario 2024",
+        )
+
+        sefip = self._create_sefip(mes="12")
+        sefip.action_gerar_sefip()
+
+        registros = self._registros_30(sefip)
+        self.assertEqual(len(registros), 1)
+        registro = registros[0]
+        self.assertEqual(registro[83:98], self._centavos(SALARIO_TESTE))
+        self.assertEqual(registro[98:113], self._centavos(400.0))
+        self.assertEqual(registro[113:128], self._centavos(400.0))
+
+    def test_sefip_rubrica_bruta_ausente_falha_alto(self):
+        """Sem rubrica de remuneração bruta: aviso no log e UserError."""
+        struct = self._criar_estrutura_sem_bruto()
+        self._criar_holerite(
+            self.contract_valor,
+            "2024-05-01",
+            "2024-05-31",
+            struct=struct,
+            name="Holerite sem bruto",
+        )
+        sefip = self._create_sefip(mes="5")
+        with self.assertLogs(LOGGER_RUBRICAS, level="WARNING") as log:
+            with self.assertRaises(UserError):
+                sefip.action_gerar_sefip()
+        self.assertTrue(
+            any("GROSS" in mensagem for mensagem in log.output),
+            "O aviso de rubrica ausente deve citar o código GROSS.",
+        )
+
+
+@tagged("post_install", "-at_install")
+class TestCaged(ArquivosGovernoCommon):
     def _create_caged(self, **kwargs):
         vals = {
             "company_id": self.company.id,


### PR DESCRIPTION
Onda A do backlog (RF-07 do PRD). Corrige o defeito que fazia SEFIP e DIRF saírem **com valores R$ 0,00 silenciosamente**.

## O bug
Os geradores buscavam a linha do holerite pelo código **`"BRUTO"`, que não existe** na folha brasileira — a remuneração bruta é a regra **`GROSS`**. Passou meses invisível porque os testes só checavam presença de substring (`"DIRF|"`, nome do funcionário), **nunca valor**.

Conferindo todos os códigos consumidos, havia **mais zeros silenciosos** além do `BRUTO`:

| Verba | Antes | Faltava |
|---|---|---|
| Remuneração bruta | `BRUTO` (inexistente) | → `GROSS` |
| INSS | `INSS` | `INSS_13` (13º), `CONTRIB_RPPS` (estatutário) |
| IRRF | `IRRF` | `IRRF_13` (13º) |
| FGTS | `FGTS` | `FGTS_13` (rescisão) |

Ou seja: **13º e estatutário também saíam zerados.** Cada verba passa a ser uma tupla de códigos equivalentes, **somados** — necessário na rescisão, que tem `INSS` e `INSS_13` no mesmo holerite (antes só a primeira linha era considerada).

## Deixa de mentir em silêncio
Novo helper `somar_rubricas` registra warning citando os códigos procurados e os holerites afetados; os geradores levantam `UserError` quando **existem holerites no período mas o total é zero**. Gerar arquivo zerado sem avisar é pior que falhar.

## Testes agora asseguram valor
Reescritos com contrato determinístico de R$ 5.000, assertando **por posição fixa**:
```
SEFIP REG30 [83:128]: '000000000500000' '000000000051882' '000000000040000'
DIRF RTRT fev:  RTRT|000000000500000|
```
(antes da correção: `000000000000000`). Cobre também 13º salário e o caso de rubrica ausente. **20 testes, 0 falha/0 erro**; black/flake8/pylint_odoo OK.

## ⚠ Contexto de escopo — leiaute NÃO foi reescrito (de propósito)
Um parecer fiscal levantado nesta rodada indica que **as três obrigações deste módulo estão extintas ou em resíduo**:

| Obrigação | Status |
|---|---|
| **DIRF** | Extinta (IN RFB 2.096/2022 + 2.181/2024). Último fato gerador: **AC 2024**. Em 2026 não existe |
| **CAGED** | Extinto desde competência **01/2020** (Portaria SEPRT 1.127/2019) → eSocial S-2200/S-2299 |
| **SEFIP/GFIP** | Substituída pelo **FGTS Digital** desde competência **03/2024**; resíduo: competências pré-2024 e FGTS de acordos trabalhistas até 30/04/2026 (GFIP 660) |

Por isso este PR **só corrige os valores** (que importam para quem tem passivo retroativo) e **não reescreve os leiautes posicionais**. Foram catalogados ~20 defeitos de leiaute (IRRF gravado em `RTDP` em vez de `RTIRF`, `zfill` invertido, CNPJ descartado, competência 13 sem filtro de data, registros sem as larguras oficiais) para registro no PRD.

**Recomendação:** depreciar o módulo (`installable: False` + nota no README), mantendo o código como referência histórica, e direcionar o esforço para eSocial (S-1010/S-1200/S-1210/S-1299, S-2200/S-2299), FGTS Digital e EFD-Reinf R-4000. Aguardando decisão.