### PR TITLE
[FIX] l10n_br_payment_boleto: gerar boletos ao confirmar faturas em lote

### DIFF
--- a/l10n_br_payment_boleto/models/account_move.py
+++ b/l10n_br_payment_boleto/models/account_move.py
@@ -7,12 +7,14 @@ class AccountMove(models.Model):
 
     def action_post(self):
         res = super().action_post()
-        if self.payment_mode_id.generate_boletos_on_invoice:
-            self.generate_boletos()
+        for move in self:
+            if move.payment_mode_id.generate_boletos_on_invoice:
+                move.generate_boletos()
 
         return res
 
     def generate_boletos(self):
+        self.ensure_one()
         if not self.payment_mode_id.payment_provider_id:
             raise UserError(
                 _(

--- a/l10n_br_payment_boleto/tests/test_automatic_transaction_create.py
+++ b/l10n_br_payment_boleto/tests/test_automatic_transaction_create.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase, tagged
 
 
@@ -23,7 +24,13 @@ class TestL10nBrPaymentBoleto(TransactionCase):
                 "name": "Test Payment Mode",
                 "bank_account_link": "fixed",
                 "fixed_journal_id": self.env["account.journal"]
-                .search([("code", "=", "CSH1")])
+                .search(
+                    [
+                        ("type", "in", ("bank", "cash")),
+                        ("company_id", "=", self.env.company.id),
+                    ],
+                    limit=1,
+                )
                 .id,
                 "generate_boletos_on_invoice": True,
                 "payment_provider_id": self.payment_provider.id,
@@ -110,3 +117,38 @@ class TestL10nBrPaymentBoleto(TransactionCase):
 
             # Assert that generate_boletos was not called
             mock_generate_boletos.assert_not_called()
+
+    def test_generate_boletos_of_several_invoices(self):
+        """
+        Test the generation of boletos when several invoices are posted at once.
+
+        `action_post` receives a recordset whenever the user confirms invoices
+        from the list view or a job posts them in batch. Reading
+        `payment_mode_id` off the whole recordset raised a singleton error, so
+        no boleto was generated and the posting itself failed.
+
+        Expected Result:
+        - `generate_boletos` is called once for each invoice of the recordset.
+        """
+        other_move = self.account_move.copy()
+        moves = self.account_move | other_move
+
+        with patch(
+            "odoo.addons.l10n_br_payment_boleto.models.account_move."
+            "AccountMove.generate_boletos"
+        ) as mock_generate_boletos:
+            moves.action_post()
+
+            self.assertEqual(mock_generate_boletos.call_count, 2)
+
+    def test_generate_boletos_without_provider(self):
+        """
+        Test that a payment mode without provider is reported to the user.
+
+        Expected Result:
+        - Posting the invoice raises a UserError naming the missing provider.
+        """
+        self.payment_mode.payment_provider_id = False
+
+        with self.assertRaises(UserError):
+            self.account_move.action_post()


### PR DESCRIPTION
`action_post` recebe um recordset sempre que o usuário confirma faturas pela
lista ou quando um job as posta em lote. Ler `payment_mode_id` do recordset
inteiro levantava "Expected singleton: account.move(...)", então nenhum boleto
era gerado e a própria confirmação das faturas falhava.

Cada fatura passa a ser avaliada individualmente, e `generate_boletos` deixa
explícito com `ensure_one()` que trabalha sobre uma fatura só, que é como os
módulos filhos (pinbank, inter) já a chamam.

O `setUp` dos testes também buscava o diário pelo código `CSH1` sem `limit` nem
filtro de empresa, o que quebra em base multiempresa: agora busca o primeiro
diário de banco ou caixa da empresa do teste.

Testes novos: confirmação de duas faturas de uma vez (o caso que quebrava) e
modo de pagamento sem provider configurado. Os 8 testes do módulo passam em
Odoo 16.
