### PR TITLE
[FIX] l10n_br_payment_boleto_pinbank: token por conta e dados do sacado fora do log

### DIFF
--- a/l10n_br_payment_boleto_pinbank/models/payment_provider.py
+++ b/l10n_br_payment_boleto_pinbank/models/payment_provider.py
@@ -48,27 +48,47 @@ class Paymentprovider(models.Model):
 
     # === BUSINESS METHODS === #
 
+    def _boleto_pinbank_token_param_names(self):
+        """Devolve as chaves usadas para guardar o token do provider.
+
+        O token e emitido por conta: guardar um unico token para toda a base faz
+        duas contas PinBank, ou o ambiente de teste e o de producao, usarem o
+        token uma da outra.
+
+        :return: As chaves do token e da sua expiracao.
+        :rtype: tuple
+        """
+        self.ensure_one()
+        return (
+            f"pinbank.token.{self.id}",
+            f"pinbank.token.expiration.{self.id}",
+        )
+
     def _boleto_pinbank_save_token(self, token, expire_in):
-        self.env["ir.config_parameter"].sudo().set_param("pinbank.token", token)
+        IrParamSudo = self.env["ir.config_parameter"].sudo()
+        token_key, expiration_key = self._boleto_pinbank_token_param_names()
+        IrParamSudo.set_param(token_key, token)
 
         if expire_in:
-            expiration = datetime.now() + timedelta(seconds=expire_in)
-            self.env["ir.config_parameter"].sudo().set_param(
-                "pinbank.token.expiration", expiration
-            )
+            expiration = datetime.now() + timedelta(seconds=int(expire_in))
+            IrParamSudo.set_param(expiration_key, expiration.isoformat())
 
     def _boleto_pinbank_check_existing_token(self):
-        token_expiration = (
-            self.env["ir.config_parameter"].sudo().get_param("pinbank.token.expiration")
-        )
+        IrParamSudo = self.env["ir.config_parameter"].sudo()
+        token_key, expiration_key = self._boleto_pinbank_token_param_names()
+        token_expiration = IrParamSudo.get_param(expiration_key)
         if not token_expiration:
             return False
 
+        # O parametro volta como texto: comparar direto com datetime estoura.
+        try:
+            token_expiration = datetime.fromisoformat(token_expiration)
+        except ValueError:
+            return False
         if token_expiration < datetime.now():
             return False
 
-        token = self.env["ir.config_parameter"].sudo().get_param("pinbank.token")
-        return token
+        return IrParamSudo.get_param(token_key)
 
     def _boleto_pinbank_get_token(self):
         """Get the Pin Bank access token
@@ -105,9 +125,9 @@ class Paymentprovider(models.Model):
             error_message = response_content.get("Message", "")
             raise ValidationError(
                 _(
-                    "Pin Bank: "
-                    "The communication with the API failed. "
-                    f"Pin Bank gave us the following information: '{error_message}'"
+                    "Pin Bank: The communication with the API failed. Pin Bank "
+                    "gave us the following information: '%s'",
+                    error_message,
                 )
             ) from requests.exceptions.HTTPError
 
@@ -180,11 +200,11 @@ class Paymentprovider(models.Model):
                 error_message = response_content.get("Message", "")
                 raise ValidationError(
                     _(
-                        "Pin Bank: "
-                        "The communication with the API failed. "
-                        f"Pin Bank gave us the following information: '{error_message}'",
+                        "Pin Bank: The communication with the API failed. Pin "
+                        "Bank gave us the following information: '%s'",
+                        error_message,
                     )
-                ) from requests.exceptions.HTTPError
+                ) from None
         except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
             _logger.exception("Unable to reach endpoint at %s", url)
             raise ValidationError(

--- a/l10n_br_payment_boleto_pinbank/models/payment_transaction.py
+++ b/l10n_br_payment_boleto_pinbank/models/payment_transaction.py
@@ -4,7 +4,7 @@ import re
 
 from werkzeug.urls import url_encode, url_join
 
-from odoo import _, models
+from odoo import _, api, models
 from odoo.exceptions import ValidationError
 
 from ..controllers.main import PinBankController
@@ -14,6 +14,20 @@ _logger = logging.getLogger(__name__)
 GERAR_BOLETO_ENDPOINT = "/CashIn/GerarBoletoEncrypted"
 CANCELAR_BOLETO_ENDPOINT = "/CashIn/SolicitarBaixaBoletoEncrypted"
 CONSULTAR_BOLETO_ENDPOINT = "/CashIn/ConsultarBoletoEncrypted"
+
+# Chaves que carregam dados pessoais do sacado e nao vao para o log.
+PERSONAL_DATA_KEYS = frozenset(
+    {
+        "cpfcnpj",
+        "nome",
+        "email",
+        "endereco",
+        "bairro",
+        "cep",
+        "dadossacado",
+        "base64",
+    }
+)
 
 STATE_MAPPING = {
     "PENDENTE": "pending",
@@ -105,12 +119,33 @@ class PaymentTransaction(models.Model):
                 boleto_info["boleto_pdf"] = boleto_pdf
 
             boleto_info["provider_technical_info"] = pprint.pformat(
-                boleto_response.get("Data", {})
+                self._pinbank_redact(boleto_response.get("Data", {}))
             )
 
             return boleto_info
 
         return super()._prepare_transaction_boleto_info(boleto_response)
+
+    @api.model
+    def _pinbank_redact(self, data):
+        """Devolve uma copia dos dados sem os dados pessoais do sacado.
+
+        A notificacao e a resposta do PinBank trazem nome, documento e endereco
+        do sacado, e o log de um gateway nao precisa deles.
+
+        :param data: O conteudo a limpar.
+        :return: A copia limpa, segura para registrar.
+        """
+        if isinstance(data, dict):
+            return {
+                key: "***"
+                if str(key).replace("_", "").lower() in PERSONAL_DATA_KEYS
+                else self._pinbank_redact(value)
+                for key, value in data.items()
+            }
+        elif isinstance(data, list | tuple):
+            return [self._pinbank_redact(item) for item in data]
+        return data
 
     def _send_refund_request(self, amount_to_refund=None):
         """Override of `payment` to send a refund request to PinBank.
@@ -345,7 +380,7 @@ class PaymentTransaction(models.Model):
                 "Received data for transaction with reference %s "
                 "with missing status: %s",
                 self.reference,
-                pprint.pformat(notification_data),
+                pprint.pformat(self._pinbank_redact(notification_data)),
             )
             self._set_error("PinBank: " + _("Received data with missing status."))
             return

--- a/l10n_br_payment_boleto_pinbank/tests/test_payment_transaction.py
+++ b/l10n_br_payment_boleto_pinbank/tests/test_payment_transaction.py
@@ -234,3 +234,84 @@ class TestPaymentTransaction(TransactionCase):
                 self.payment_transaction.barcode,
                 "12345678901234567890123456789012345678901234",
             )
+
+
+@tagged("at_install", "post_install")
+class TestPinbankToken(TransactionCase):
+    """O token e emitido por conta e volta do parametro como texto."""
+
+    def setUp(self):
+        super().setUp()
+        self.provider = self.env.ref(
+            "l10n_br_payment_boleto_pinbank.payment_acquirer_boleto_pinbank"
+        )
+
+    def test_token_is_saved_per_provider(self):
+        other_provider = self.provider.copy({"name": "Outra conta PinBank"})
+        self.provider._boleto_pinbank_save_token("token-um", 600)
+        other_provider._boleto_pinbank_save_token("token-dois", 600)
+
+        self.assertEqual(
+            self.provider._boleto_pinbank_check_existing_token(), "token-um"
+        )
+        self.assertEqual(
+            other_provider._boleto_pinbank_check_existing_token(), "token-dois"
+        )
+
+    def test_saved_token_is_reused(self):
+        """A segunda requisicao nao pode estourar comparando texto com data."""
+        self.provider._boleto_pinbank_save_token("token-um", 600)
+
+        self.assertEqual(
+            self.provider._boleto_pinbank_check_existing_token(),
+            "token-um",
+            "o token guardado nao foi reaproveitado",
+        )
+
+    def test_expired_token_is_discarded(self):
+        self.provider._boleto_pinbank_save_token("token-velho", 600)
+        _token_key, expiration_key = self.provider._boleto_pinbank_token_param_names()
+        self.env["ir.config_parameter"].sudo().set_param(
+            expiration_key, "2020-01-01T00:00:00"
+        )
+
+        self.assertFalse(self.provider._boleto_pinbank_check_existing_token())
+
+    def test_invalid_expiration_is_discarded(self):
+        self.provider._boleto_pinbank_save_token("token-um", 600)
+        _token_key, expiration_key = self.provider._boleto_pinbank_token_param_names()
+        self.env["ir.config_parameter"].sudo().set_param(expiration_key, "nao-e-data")
+
+        self.assertFalse(self.provider._boleto_pinbank_check_existing_token())
+
+
+@tagged("at_install", "post_install")
+class TestPinbankRedaction(TransactionCase):
+    """O boleto carrega nome, documento e endereco do sacado."""
+
+    def test_personal_data_is_dropped(self):
+        redacted = self.env["payment.transaction"]._pinbank_redact(
+            {
+                "Data": {
+                    "NossoNumero": "12345",
+                    "DadosSacado": {
+                        "CpfCnpj": "23130935000198",
+                        "Nome": "Cliente Boleto",
+                        "Endereco": "Rua das Flores",
+                    },
+                }
+            }
+        )
+
+        self.assertNotIn("23130935000198", str(redacted))
+        self.assertNotIn("Cliente Boleto", str(redacted))
+        self.assertNotIn("Rua das Flores", str(redacted))
+        self.assertEqual(redacted["Data"]["NossoNumero"], "12345")
+
+    def test_pdf_is_dropped(self):
+        """O PDF em base64 nao tem porque ficar no campo tecnico."""
+        redacted = self.env["payment.transaction"]._pinbank_redact(
+            {"Base64": "JVBERi0xLjQ="}
+        )
+
+        self.assertEqual(redacted["Base64"], "***")


### PR DESCRIPTION
Encontrado ao revisar o padrao de log dos modulos de cobranca.

## Token: a segunda requisicao quebrava

`_boleto_pinbank_save_token` gravava a expiracao como `datetime` e
`_boleto_pinbank_check_existing_token` lia de volta do `ir.config_parameter`,
que devolve texto, comparando com `datetime.now()`:

```
TypeError: '<' not supported between instances of 'str' and 'datetime.datetime'
```

Ou seja, enquanto existisse token guardado, toda requisicao seguinte a primeira
estourava. Confirmado com teste: revertendo a correcao, os tres testes de token
falham com esse TypeError.

A expiracao passa a ser gravada e lida em ISO, e as duas chaves levam o id do
provider, para que duas contas PinBank, ou o ambiente de teste e o de producao
na mesma base, nao usem o token uma da outra.

## Dados do sacado fora do log

A notificacao registrada no log e o campo tecnico da transacao traziam nome,
documento e endereco do sacado, e ainda o PDF do boleto em base64. Passam por
uma limpeza antes de serem gravados. O payload da requisicao nunca foi logado
neste modulo, so a URL, entao nao havia vazamento no envio.

## Traducoes

As mensagens de erro usavam f-string dentro de `_()`, o que nao gera string
traduzivel.

## Testes

22 testes do modulo verdes em Odoo 16, sendo 6 novos: token por conta, token
reaproveitado (o caso que quebrava), token expirado, expiracao invalida e a
limpeza dos dados do sacado e do PDF.
