### PR TITLE
[16.0][IMP] l10n_br_hr_payroll: dados de demo com ciclo completo de folha

### DIFF
--- a/l10n_br_hr_payroll/__manifest__.py
+++ b/l10n_br_hr_payroll/__manifest__.py
@@ -29,9 +29,11 @@
         "views/hr_payslip_views.xml",
     ],
     "demo": [
+        "demo/resource_calendar_payroll_demo.xml",
         "demo/hr_employee_payroll_demo.xml",
         "demo/hr_contract_payroll_demo.xml",
         "demo/hr_payslip_demo.xml",
+        "demo/hr_payslip_run_demo.xml",
     ],
     "installable": True,
     "auto_install": False,

--- a/l10n_br_hr_payroll/demo/hr_contract_payroll_demo.xml
+++ b/l10n_br_hr_payroll/demo/hr_contract_payroll_demo.xml
@@ -1,20 +1,33 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
 
+    <!--
+        Parte 1 - Complemento dos contratos de demonstração do
+        l10n_br_hr_contract com a estrutura salarial e os adicionais da folha.
+
+        A jornada de 44h/semana (`demo_calendar_clt_44h`) é aplicada aos
+        contratos que declaram 220 horas mensais, para que o divisor do
+        salário-hora derivado do calendário (RF-26) coincida com o contrato.
+        O contrato do aprendiz (30h/150h) fica no calendário padrão da empresa.
+    -->
+
     <!-- João — Estrutura CLT -->
         <record id="l10n_br_hr_contract.demo_contract_joao" model="hr.contract">
             <field name="struct_id" ref="structure_clt" />
+            <field name="resource_calendar_id" ref="demo_calendar_clt_44h" />
         </record>
 
         <!-- Maria — Estrutura CLT + periculosidade -->
         <record id="l10n_br_hr_contract.demo_contract_maria" model="hr.contract">
             <field name="struct_id" ref="structure_clt" />
+            <field name="resource_calendar_id" ref="demo_calendar_clt_44h" />
             <field name="l10n_br_periculosidade" eval="True" />
         </record>
 
         <!-- Pedro — Estrutura CLT + insalubridade grau máximo -->
         <record id="l10n_br_hr_contract.demo_contract_pedro" model="hr.contract">
             <field name="struct_id" ref="structure_clt" />
+            <field name="resource_calendar_id" ref="demo_calendar_clt_44h" />
             <field name="l10n_br_insalubridade" eval="True" />
             <field name="l10n_br_grau_insalubridade">maximo</field>
         </record>
@@ -22,6 +35,7 @@
         <!-- Ana — Estrutura Estatutário -->
         <record id="l10n_br_hr_contract.demo_contract_ana" model="hr.contract">
             <field name="struct_id" ref="structure_estatuto" />
+            <field name="resource_calendar_id" ref="demo_calendar_clt_44h" />
         </record>
 
         <!-- Lucas — Estrutura CLT (aprendiz usa mesma estrutura) -->
@@ -31,6 +45,63 @@
 
         <!-- Carla — Estrutura CLT -->
         <record id="l10n_br_hr_contract.demo_contract_carla" model="hr.contract">
+            <field name="struct_id" ref="structure_clt" />
+            <field name="resource_calendar_id" ref="demo_calendar_clt_44h" />
+        </record>
+
+        <!--
+        Parte 2 - Contratos dos funcionários criados neste módulo.
+    -->
+
+        <!-- Renata - CLT, RGPS, mensal, R$ 15.000 (acima do teto do INSS) -->
+        <record id="demo_contract_renata" model="hr.contract">
+            <field name="name">Contrato Renata Alves Machado</field>
+            <field name="employee_id" ref="demo_employee_renata" />
+            <field name="department_id" ref="l10n_br_hr.demo_department_ti" />
+            <field name="job_id" ref="l10n_br_hr.demo_job_analista_sistemas" />
+            <field name="wage">15000.00</field>
+            <field name="date_start">2024-01-02</field>
+            <field name="state">open</field>
+            <field name="labor_regime_id" ref="l10n_br_hr_contract.labor_regime_clt" />
+            <field
+            name="labor_bond_type_id"
+            ref="l10n_br_hr_contract.labor_bond_type_10"
+        />
+            <field
+            name="admission_type_id"
+            ref="l10n_br_hr_contract.admission_type_1"
+        />
+            <field name="welfare_policy">rgps</field>
+            <field name="salary_unit" ref="l10n_br_hr_contract.salary_unit_5" />
+            <field name="weekly_hours">44</field>
+            <field name="monthly_hours">220</field>
+            <field name="resource_calendar_id" ref="demo_calendar_clt_44h" />
+            <field name="struct_id" ref="structure_clt" />
+        </record>
+
+        <!-- Josefa - CLT, RGPS, mensal, salário mínimo 2026 (R$ 1.621,00) -->
+        <record id="demo_contract_josefa" model="hr.contract">
+            <field name="name">Contrato Josefa Ribeiro Campos</field>
+            <field name="employee_id" ref="demo_employee_josefa" />
+            <field name="department_id" ref="l10n_br_hr.demo_department_operacional" />
+            <field name="job_id" ref="l10n_br_hr.demo_job_operador_industrial" />
+            <field name="wage">1621.00</field>
+            <field name="date_start">2024-01-02</field>
+            <field name="state">open</field>
+            <field name="labor_regime_id" ref="l10n_br_hr_contract.labor_regime_clt" />
+            <field
+            name="labor_bond_type_id"
+            ref="l10n_br_hr_contract.labor_bond_type_10"
+        />
+            <field
+            name="admission_type_id"
+            ref="l10n_br_hr_contract.admission_type_1"
+        />
+            <field name="welfare_policy">rgps</field>
+            <field name="salary_unit" ref="l10n_br_hr_contract.salary_unit_5" />
+            <field name="weekly_hours">44</field>
+            <field name="monthly_hours">220</field>
+            <field name="resource_calendar_id" ref="demo_calendar_clt_44h" />
             <field name="struct_id" ref="structure_clt" />
         </record>
 

--- a/l10n_br_hr_payroll/demo/hr_employee_payroll_demo.xml
+++ b/l10n_br_hr_payroll/demo/hr_employee_payroll_demo.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
 
+    <!--
+        Parte 1 - Complemento dos funcionários de demonstração do l10n_br_hr
+        com os campos de folha (tipo de contrato, dependentes de IRRF, filhos
+        para salário família, moléstia grave).
+    -->
+
     <!-- João — CLT, 2 dep. IRRF, 2 filhos SF -->
         <record id="l10n_br_hr.demo_employee_joao" model="hr.employee">
             <field name="l10n_br_tipo_contrato">clt</field>
@@ -41,6 +47,71 @@
             <field name="l10n_br_pcd" eval="True" />
             <field name="l10n_br_molestia_grave" eval="True" />
             <field name="l10n_br_cid_molestia">C50</field>
+        </record>
+
+        <!--
+        Parte 2 - Funcionários criados aqui para cobrir casos de cálculo que o
+        conjunto do l10n_br_hr não cobre:
+
+          - Renata: salário acima do TETO do INSS (2026: R$ 8.475,55), único
+            caso CLT que exercita a 4ª faixa até o teto e a limitação da
+            contribuição (a Ana ganha R$ 8.500,00, mas é estatutária/RPPS,
+            regra diferente).
+          - Josefa: salário mínimo com filhos, único caso que efetivamente
+            gera cota de SALÁRIO FAMÍLIA (limite 2026: R$ 1.980,38 de
+            remuneração). Os demais têm salário acima do limite e a cota sai
+            zerada mesmo com filhos declarados.
+    -->
+
+        <!-- Renata Alves Machado - CLT acima do teto do INSS -->
+        <record id="demo_employee_renata" model="hr.employee">
+            <field name="name">Renata Alves Machado</field>
+            <field name="gender">female</field>
+            <field name="birthday">1979-04-08</field>
+            <field name="marital">married</field>
+            <field name="country_id" ref="base.br" />
+            <field name="department_id" ref="l10n_br_hr.demo_department_ti" />
+            <field name="job_id" ref="l10n_br_hr.demo_job_analista_sistemas" />
+            <field name="cnpj_cpf">987.654.321-00</field>
+            <field name="pis_pasep">11223344554</field>
+            <field name="ctps">78901</field>
+            <field name="ctps_series">0007</field>
+            <field name="ctps_date">2005-03-01</field>
+            <field name="ctps_uf_id" ref="base.state_br_sp" />
+            <field name="father_name">Antônio Machado Filho</field>
+            <field name="mother_name">Vera Lúcia Alves</field>
+            <field name="ethnicity" ref="l10n_br_hr.ethnicity_1" />
+            <field name="blood_type">b+</field>
+            <field name="registration">EMP007</field>
+            <field name="employee_relationship_type">funcionario</field>
+            <field name="l10n_br_tipo_contrato">clt</field>
+            <field name="l10n_br_irrf_dependentes">0</field>
+        </record>
+
+        <!-- Josefa Ribeiro Campos - CLT salário mínimo, 2 filhos (sal. família) -->
+        <record id="demo_employee_josefa" model="hr.employee">
+            <field name="name">Josefa Ribeiro Campos</field>
+            <field name="gender">female</field>
+            <field name="birthday">1994-12-02</field>
+            <field name="marital">single</field>
+            <field name="country_id" ref="base.br" />
+            <field name="department_id" ref="l10n_br_hr.demo_department_operacional" />
+            <field name="job_id" ref="l10n_br_hr.demo_job_operador_industrial" />
+            <field name="cnpj_cpf">456.789.123-64</field>
+            <field name="pis_pasep">99887766551</field>
+            <field name="ctps">89012</field>
+            <field name="ctps_series">0008</field>
+            <field name="ctps_date">2018-08-15</field>
+            <field name="ctps_uf_id" ref="base.state_br_sp" />
+            <field name="father_name">Sebastião Campos</field>
+            <field name="mother_name">Marlene Ribeiro Campos</field>
+            <field name="ethnicity" ref="l10n_br_hr.ethnicity_3" />
+            <field name="blood_type">o+</field>
+            <field name="registration">EMP008</field>
+            <field name="employee_relationship_type">funcionario</field>
+            <field name="l10n_br_tipo_contrato">clt</field>
+            <field name="l10n_br_irrf_dependentes">2</field>
+            <field name="l10n_br_num_filhos_sf">2</field>
         </record>
 
 </odoo>

--- a/l10n_br_hr_payroll/demo/hr_payslip_demo.xml
+++ b/l10n_br_hr_payroll/demo/hr_payslip_demo.xml
@@ -224,4 +224,129 @@
             <field name="date_to" eval="time.strftime('%Y-03-31')" />
         </record>
 
+        <!-- Renata - CLT R$15.000, acima do teto do INSS -->
+        <record id="demo_payslip_renata" model="hr.payslip">
+            <field
+            name="name"
+            eval="time.strftime('Holerite 03/%Y - Renata Alves Machado')"
+        />
+            <field name="employee_id" ref="demo_employee_renata" />
+            <field name="contract_id" ref="demo_contract_renata" />
+            <field name="struct_id" ref="structure_clt" />
+            <field name="date_from" eval="time.strftime('%Y-03-01')" />
+            <field name="date_to" eval="time.strftime('%Y-03-31')" />
+        </record>
+
+        <!-- Josefa - CLT salário mínimo, 2 filhos (salário família) -->
+        <record id="demo_payslip_josefa" model="hr.payslip">
+            <field
+            name="name"
+            eval="time.strftime('Holerite 03/%Y - Josefa Ribeiro Campos')"
+        />
+            <field name="employee_id" ref="demo_employee_josefa" />
+            <field name="contract_id" ref="demo_contract_josefa" />
+            <field name="struct_id" ref="structure_clt" />
+            <field name="date_from" eval="time.strftime('%Y-03-01')" />
+            <field name="date_to" eval="time.strftime('%Y-03-31')" />
+        </record>
+
+        <!-- ===== Abril - folha completa (todos os funcionários) =====
+             O holerite de abril do João já está declarado acima (com horas
+             extras 50%). Aqui entram os demais, para que o lote 04 tenha a
+             empresa inteira e sirva de contraste com o lote 03 já fechado. -->
+
+        <!-- Maria - Abril -->
+        <record id="demo_payslip_maria_04" model="hr.payslip">
+            <field
+            name="name"
+            eval="time.strftime('Holerite 04/%Y - Maria Fernanda Santos')"
+        />
+            <field name="employee_id" ref="l10n_br_hr.demo_employee_maria" />
+            <field name="contract_id" ref="l10n_br_hr_contract.demo_contract_maria" />
+            <field name="struct_id" ref="structure_clt" />
+            <field name="date_from" eval="time.strftime('%Y-04-01')" />
+            <field name="date_to" eval="time.strftime('%Y-04-30')" />
+        </record>
+
+        <!-- Pedro - Abril, com 4 horas noturnas (hora reduzida) -->
+        <record id="demo_payslip_pedro_04" model="hr.payslip">
+            <field
+            name="name"
+            eval="time.strftime('Holerite 04/%Y - Pedro Henrique Oliveira')"
+        />
+            <field name="employee_id" ref="l10n_br_hr.demo_employee_pedro" />
+            <field name="contract_id" ref="l10n_br_hr_contract.demo_contract_pedro" />
+            <field name="struct_id" ref="structure_clt" />
+            <field name="date_from" eval="time.strftime('%Y-04-01')" />
+            <field name="date_to" eval="time.strftime('%Y-04-30')" />
+            <field name="l10n_br_horas_noturnas">4</field>
+            <field name="l10n_br_usar_hora_reduzida" eval="True" />
+        </record>
+
+        <!-- Ana - Abril (estatutária) -->
+        <record id="demo_payslip_ana_04" model="hr.payslip">
+            <field
+            name="name"
+            eval="time.strftime('Holerite 04/%Y - Ana Beatriz Souza')"
+        />
+            <field name="employee_id" ref="l10n_br_hr.demo_employee_ana" />
+            <field name="contract_id" ref="l10n_br_hr_contract.demo_contract_ana" />
+            <field name="struct_id" ref="structure_estatuto" />
+            <field name="date_from" eval="time.strftime('%Y-04-01')" />
+            <field name="date_to" eval="time.strftime('%Y-04-30')" />
+        </record>
+
+        <!-- Lucas - Abril (aprendiz: INSS 2%, FGTS 2%) -->
+        <record id="demo_payslip_lucas_04" model="hr.payslip">
+            <field
+            name="name"
+            eval="time.strftime('Holerite 04/%Y - Lucas Gabriel Costa')"
+        />
+            <field name="employee_id" ref="l10n_br_hr.demo_employee_lucas" />
+            <field name="contract_id" ref="l10n_br_hr_contract.demo_contract_lucas" />
+            <field name="struct_id" ref="structure_clt" />
+            <field name="date_from" eval="time.strftime('%Y-04-01')" />
+            <field name="date_to" eval="time.strftime('%Y-04-30')" />
+        </record>
+
+        <!-- Carla - Abril (isenta de IRRF por moléstia grave) -->
+        <record id="demo_payslip_carla_04" model="hr.payslip">
+            <field
+            name="name"
+            eval="time.strftime('Holerite 04/%Y - Carla Regina Pereira')"
+        />
+            <field name="employee_id" ref="l10n_br_hr.demo_employee_carla" />
+            <field name="contract_id" ref="l10n_br_hr_contract.demo_contract_carla" />
+            <field name="struct_id" ref="structure_clt" />
+            <field name="date_from" eval="time.strftime('%Y-04-01')" />
+            <field name="date_to" eval="time.strftime('%Y-04-30')" />
+        </record>
+
+        <!-- Renata - Abril -->
+        <record id="demo_payslip_renata_04" model="hr.payslip">
+            <field
+            name="name"
+            eval="time.strftime('Holerite 04/%Y - Renata Alves Machado')"
+        />
+            <field name="employee_id" ref="demo_employee_renata" />
+            <field name="contract_id" ref="demo_contract_renata" />
+            <field name="struct_id" ref="structure_clt" />
+            <field name="date_from" eval="time.strftime('%Y-04-01')" />
+            <field name="date_to" eval="time.strftime('%Y-04-30')" />
+        </record>
+
+        <!-- Josefa - Abril, com 1 falta injustificada (FALTAS + desconto DSR) -->
+        <record id="demo_payslip_josefa_04" model="hr.payslip">
+            <field
+            name="name"
+            eval="time.strftime('Holerite 04/%Y - Josefa Ribeiro Campos')"
+        />
+            <field name="employee_id" ref="demo_employee_josefa" />
+            <field name="contract_id" ref="demo_contract_josefa" />
+            <field name="struct_id" ref="structure_clt" />
+            <field name="date_from" eval="time.strftime('%Y-04-01')" />
+            <field name="date_to" eval="time.strftime('%Y-04-30')" />
+            <field name="l10n_br_faltas_injustificadas">1</field>
+        </record>
+
 </odoo>

--- a/l10n_br_hr_payroll/demo/hr_payslip_run_demo.xml
+++ b/l10n_br_hr_payroll/demo/hr_payslip_run_demo.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <!--
+        Lotes de holerite (hr.payslip.run) da demonstração.
+
+        Dois meses consecutivos, deliberadamente em estados diferentes para que
+        a demo mostre o ciclo de vida completo e não só o rascunho:
+
+          - Lote 03: FECHADO, com todos os holerites confirmados (done).
+          - Lote 04: ABERTO, com os holerites já calculados (verify), pronto
+            para o roteiro "revisar e confirmar" na tela.
+
+        A competência é sempre o ano corrente (time.strftime), de modo que as
+        tabelas fiscais resolvidas sejam as vigentes (INSS, IRRF, salário
+        família), sem precisar reeditar a demo a cada virada de ano.
+    -->
+
+    <record id="demo_payslip_run_03" model="hr.payslip.run">
+        <field name="name" eval="time.strftime('Folha 03/%Y')" />
+        <field name="date_start" eval="time.strftime('%Y-03-01')" />
+        <field name="date_end" eval="time.strftime('%Y-03-31')" />
+        <field
+            name="slip_ids"
+            eval="[(6, 0, [
+                ref('demo_payslip_joao'),
+                ref('demo_payslip_maria'),
+                ref('demo_payslip_pedro'),
+                ref('demo_payslip_ana'),
+                ref('demo_payslip_lucas'),
+                ref('demo_payslip_carla'),
+                ref('demo_payslip_renata'),
+                ref('demo_payslip_josefa'),
+            ])]"
+        />
+    </record>
+
+    <record id="demo_payslip_run_04" model="hr.payslip.run">
+        <field name="name" eval="time.strftime('Folha 04/%Y')" />
+        <field name="date_start" eval="time.strftime('%Y-04-01')" />
+        <field name="date_end" eval="time.strftime('%Y-04-30')" />
+        <field
+            name="slip_ids"
+            eval="[(6, 0, [
+                ref('demo_payslip_joao_04'),
+                ref('demo_payslip_maria_04'),
+                ref('demo_payslip_pedro_04'),
+                ref('demo_payslip_ana_04'),
+                ref('demo_payslip_lucas_04'),
+                ref('demo_payslip_carla_04'),
+                ref('demo_payslip_renata_04'),
+                ref('demo_payslip_josefa_04'),
+            ])]"
+        />
+    </record>
+
+    <!--
+        Calcula TODOS os holerites da demo (inclusive os meses do João fora dos
+        lotes). Sem isto os holerites ficam em rascunho e sem linhas: as telas
+        de folha abrem vazias. Até aqui a chamada só existia no demo do
+        l10n_br_hr_vacation, então instalar apenas este módulo não calculava nada.
+    -->
+    <function model="hr.payslip" name="_demo_compute_payslips" />
+
+    <!-- Fecha o lote de março (holerites confirmados). -->
+    <function
+        model="hr.payslip.run"
+        name="_demo_confirm_runs"
+        eval="[[ref('demo_payslip_run_03')]]"
+    />
+
+</odoo>

--- a/l10n_br_hr_payroll/demo/resource_calendar_payroll_demo.xml
+++ b/l10n_br_hr_payroll/demo/resource_calendar_payroll_demo.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <!--
+        Jornada padrão CLT: 44 horas semanais (art. 7º, XIII, CF/88).
+
+        O calendário padrão do Odoo tem 40h (seg-sex, 8h/dia). Aqui a jornada
+        brasileira é completada com o sábado pela manhã, chegando às 44h que os
+        contratos de demonstração declaram em `weekly_hours`/`monthly_hours`.
+
+        Isso importa para o cálculo: `hr.contract._l10n_br_divisor_horas_mensais()`
+        deriva o divisor do salário-hora do CALENDÁRIO (horas semanais x 5), não
+        do campo `monthly_hours`. Sem este calendário o divisor cai em 200
+        (40h x 5) e as horas extras da demo saem calculadas com salário-hora de
+        200 avos, divergindo dos 220 avos declarados no contrato.
+    -->
+    <record id="demo_calendar_clt_44h" model="resource.calendar">
+        <field name="name">Jornada CLT 44h/semana</field>
+        <field name="tz">America/Sao_Paulo</field>
+        <field name="hours_per_day">8.0</field>
+    </record>
+
+    <!-- Sábado 08:00-12:00 (as 40h de seg-sex vêm do default do Odoo) -->
+    <record id="demo_calendar_clt_44h_sabado" model="resource.calendar.attendance">
+        <field name="name">Saturday Morning</field>
+        <field name="calendar_id" ref="demo_calendar_clt_44h" />
+        <field name="dayofweek">5</field>
+        <field name="hour_from">8.0</field>
+        <field name="hour_to">12.0</field>
+        <field name="day_period">morning</field>
+    </record>
+
+</odoo>

--- a/l10n_br_hr_payroll/models/__init__.py
+++ b/l10n_br_hr_payroll/models/__init__.py
@@ -6,3 +6,4 @@ from . import fiscal_tables
 from . import hr_employee
 from . import hr_contract
 from . import hr_payslip
+from . import hr_payslip_run

--- a/l10n_br_hr_payroll/models/hr_payslip_run.py
+++ b/l10n_br_hr_payroll/models/hr_payslip_run.py
@@ -1,0 +1,45 @@
+# Copyright 2024 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import logging
+
+from odoo import api, models
+
+_logger = logging.getLogger(__name__)
+
+
+class HrPayslipRun(models.Model):
+    _inherit = "hr.payslip.run"
+
+    @api.model
+    def _demo_confirm_runs(self, run_ids):
+        """Confirm demo payslip batches: confirm every slip and close the batch.
+
+        Called from demo XML via ``<function>``. Demo data must reproduce the
+        FULL life cycle -- a batch left in draft with uncomputed payslips shows
+        empty screens, which is exactly what a commercial demo must not do.
+
+        ``action_payslip_done`` recomputes the payslip before confirming (OCA
+        behaviour), so calling this on already-computed slips is safe and
+        idempotent: slips already in ``done`` are skipped.
+
+        Args:
+            run_ids: ids of the ``hr.payslip.run`` records to confirm.
+        """
+        runs = self.browse(run_ids).exists()
+        for run in runs:
+            slips = run.slip_ids.filtered(lambda s: s.state not in ("done", "cancel"))
+            for slip in slips:
+                try:
+                    slip.action_payslip_done()
+                except Exception:
+                    _logger.warning(
+                        "Demo: falha ao confirmar holerite %s", slip.name, exc_info=True
+                    )
+            run.close_payslip_run()
+            _logger.info(
+                "Demo: lote %s fechado com %d holerites confirmados",
+                run.name,
+                len(run.slip_ids.filtered(lambda s: s.state == "done")),
+            )
+        return True


### PR DESCRIPTION
## O problema

O l10n_br_hr_payroll ja tinha demo de funcionarios, contratos e 16 holerites,
mas TODOS ficavam em draft com 0 linhas em hr_payslip_line: o unico gatilho de
calculo (_demo_compute_payslips) morava no demo do l10n_br_hr_vacation, entao
quem instala so a folha ve telas vazias. Lote de holerite (hr.payslip.run)
nunca existiu no demo. Detalhe traiçoeiro: erro em demo data nao quebra o
install, o Odoo loga um WARNING e descarta o pacote de demo INTEIRO, com exit
0 e modulo installed.

## O que este PR entrega

- Jornada CLT 44h/semana (resource.calendar): sem ela o divisor de hora extra
  saia em 200 avos em vez de 220 (o divisor deriva do calendario, nao do
  monthly_hours).
- Dois funcionarios novos cobrindo casos que faltavam: salario acima do teto
  do INSS 2026 (contribuicao travada em 988,09) e salario familia (2 filhos,
  com falta injustificada e desconto de DSR em abril).
- Lote Folha 03/2026: 8 holerites calculados, CONFIRMADOS (done) e lote
  fechado. Lote Folha 04/2026: calculado (verify) e deixado aberto de
  proposito, para o roteiro "revisar e confirmar" em tela.
- Gatilho _demo_confirm_runs no PROPRIO modulo: idempotente, try/except por
  holerite (falha isolada nao derruba o demo inteiro), chamado por <function>
  no XML.
- Competencias pelo ano corrente (time.strftime): a demo nao apodrece na
  virada do ano.

## Validacao

- Install limpo em banco novo com demo: 25 holerites (8 done + 17 verify),
  197 linhas, 2 lotes; sem WARNING de demo.
- Suite do modulo: 223 testes, 0 falhas.
- Stack completo (l10n_generic_coa + payroll + vacation + payroll_account +
  payroll_report): instala sem erro, ferias/13o/rescisao do modulo de ferias
  saem calculados.
- pre-commit: Passed em todos os arquivos.
- Valores de INSS/IRRF/FGTS/salario familia conferidos manualmente contra as
  tabelas 2026 dos CSVs do proprio modulo.

## Limitacoes conhecidas (fora do escopo deste PR)

1. Os holerites 2026 calculam SEM o redutor do IRRF da Lei 15.270/2025:
   depende do #415 (fix/irrf-2026-redutor). Sem conflito entre os PRs: o demo
   calcula na instalacao, entao os valores se ajustam sozinhos quando o #415
   mesclar. Ate la, a demo mostra IRRF para quem hoje e isento.
2. O demo e mono-empresa (funcionarios sem company_id caem na main company):
   num banco multi-empresa, trocar de empresa esconde tudo. E nao existe
   rubrica patronal (INSS empresa, RAT/FAP, terceiros) nem qualquer variacao
   por regime tributario (Simples/Presumido/Real) na folha ou na
   contabilizacao. Registrado como evolucao de produto, e requisito para demo
   comercial multi-regime.
